### PR TITLE
Add 3 new analysis tabs: Bypass Diode (enhanced), LeTID, Gel Content

### DIFF
--- a/components/data-analysis/BypassDiodeAnalysis.tsx
+++ b/components/data-analysis/BypassDiodeAnalysis.tsx
@@ -1,0 +1,366 @@
+// @ts-nocheck
+"use client"
+
+import { useState, useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  ResponsiveContainer, ScatterChart, Scatter, LineChart, Line,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine
+} from "recharts"
+import { Zap, Thermometer, CheckCircle, AlertTriangle } from "lucide-react"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DiodeVfData {
+  moduleId: string
+  diodeIdx: number
+  temp: number
+  vf: number
+}
+
+interface StressTestPoint {
+  time: number // minutes
+  moduleId: string
+  tj: number   // junction temp °C
+}
+
+// ─── Sample Data: 3 modules × 3 diodes, Vf decreasing ~2mV/°C ──────────────
+
+function generateVfData(): DiodeVfData[] {
+  const modules = ["MOD-A01", "MOD-A02", "MOD-A03"]
+  const temps = [25, 40, 55, 70]
+  const data: DiodeVfData[] = []
+
+  modules.forEach((moduleId, mi) => {
+    for (let di = 0; di < 3; di++) {
+      const baseVf = 0.58 - mi * 0.01 - di * 0.005 // slight per-diode variation
+      temps.forEach(temp => {
+        const vf = baseVf - 0.002 * (temp - 25) + (Math.random() - 0.5) * 0.003
+        data.push({ moduleId, diodeIdx: di + 1, temp, vf: parseFloat(vf.toFixed(4)) })
+      })
+    }
+  })
+  return data
+}
+
+function generateStressTestData(): StressTestPoint[] {
+  const modules = ["MOD-A01", "MOD-A02", "MOD-A03"]
+  const points: StressTestPoint[] = []
+
+  modules.forEach((moduleId, mi) => {
+    const baseTj = 72 + mi * 2 // different thermal behaviour per module
+    for (let t = 0; t <= 60; t += 5) {
+      // exponential rise to steady state
+      const tj = baseTj + (80 - baseTj) * (1 - Math.exp(-t / 20)) * 0.85 + (Math.random() - 0.5) * 1.5
+      points.push({ time: t, moduleId, tj: parseFloat(tj.toFixed(1)) })
+    }
+  })
+  return points
+}
+
+// ─── Linear regression helper ────────────────────────────────────────────────
+
+function linearRegression(points: { x: number; y: number }[]) {
+  const n = points.length
+  if (n < 2) return { slope: 0, intercept: 0, r2: 0 }
+  const sumX = points.reduce((s, p) => s + p.x, 0)
+  const sumY = points.reduce((s, p) => s + p.y, 0)
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0)
+  const sumX2 = points.reduce((s, p) => s + p.x * p.x, 0)
+  const sumY2 = points.reduce((s, p) => s + p.y * p.y, 0)
+
+  const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX)
+  const intercept = (sumY - slope * sumX) / n
+
+  const ssTot = sumY2 - (sumY * sumY) / n
+  const ssRes = points.reduce((s, p) => s + Math.pow(p.y - (slope * p.x + intercept), 2), 0)
+  const r2 = ssTot !== 0 ? 1 - ssRes / ssTot : 1
+
+  return { slope, intercept, r2 }
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function BypassDiodeAnalysis() {
+  const vfData = useMemo(() => generateVfData(), [])
+  const stressData = useMemo(() => generateStressTestData(), [])
+
+  // Aggregate Vf by temperature for scatter + regression
+  const vfByTemp = useMemo(() => {
+    const temps = [25, 40, 55, 70]
+    return temps.map(temp => {
+      const values = vfData.filter(d => d.temp === temp).map(d => d.vf)
+      const mean = values.reduce((a, b) => a + b, 0) / values.length
+      return { temp, meanVf: parseFloat(mean.toFixed(4)), values }
+    })
+  }, [vfData])
+
+  // Linear regression on mean Vf vs Temperature
+  const regression = useMemo(() => {
+    const points = vfByTemp.map(d => ({ x: d.temp, y: d.meanVf }))
+    return linearRegression(points)
+  }, [vfByTemp])
+
+  // Extrapolated Vf at 75°C
+  const vfAt75 = parseFloat((regression.slope * 75 + regression.intercept).toFixed(4))
+
+  // Scatter chart data: individual diode points + regression line
+  const scatterPoints = useMemo(() =>
+    vfData.map(d => ({ temp: d.temp, vf: d.vf, label: `${d.moduleId} D${d.diodeIdx}` })),
+    [vfData]
+  )
+
+  const regressionLine = useMemo(() => {
+    return [20, 25, 40, 55, 70, 75, 80].map(t => ({
+      temp: t,
+      vfFit: parseFloat((regression.slope * t + regression.intercept).toFixed(4))
+    }))
+  }, [regression])
+
+  // Stress test chart data pivoted
+  const stressChartData = useMemo(() => {
+    const times = Array.from(new Set(stressData.map(d => d.time))).sort((a, b) => a - b)
+    return times.map(time => {
+      const row: Record<string, number> = { time }
+      stressData.filter(d => d.time === time).forEach(d => {
+        row[d.moduleId] = d.tj
+      })
+      return row
+    })
+  }, [stressData])
+
+  // Summary stats
+  const totalDiodes = vfData.length / 4 // 4 temps per diode
+  const allVf = vfData.map(d => d.vf)
+  const avgVf = parseFloat((allVf.reduce((a, b) => a + b, 0) / allVf.length).toFixed(3))
+  const maxTj = Math.max(...stressData.map(d => d.tj))
+  const tjMax = 80
+  const passCount = stressData.filter(d => d.time === 60).filter(d => d.tj <= tjMax).length
+  const totalModules = 3
+  const passRate = parseFloat(((passCount / totalModules) * 100).toFixed(1))
+
+  const MODULE_COLORS: Record<string, string> = {
+    "MOD-A01": "#3b82f6",
+    "MOD-A02": "#22c55e",
+    "MOD-A03": "#f59e0b",
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className="text-2xl font-bold text-blue-600">{totalDiodes}</div>
+            <div className="text-xs text-gray-500">Diodes Tested</div>
+          </CardContent>
+        </Card>
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className={`text-2xl font-bold ${passRate >= 90 ? "text-green-600" : "text-amber-600"}`}>
+              {passRate}%
+            </div>
+            <div className="text-xs text-gray-500">Pass Rate</div>
+          </CardContent>
+        </Card>
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className="text-2xl font-bold text-purple-600">{avgVf} V</div>
+            <div className="text-xs text-gray-500">Avg Vf</div>
+          </CardContent>
+        </Card>
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className={`text-2xl font-bold ${maxTj <= tjMax ? "text-green-600" : "text-red-600"}`}>
+              {maxTj}°C
+            </div>
+            <div className="text-xs text-gray-500">Max Tj</div>
+          </CardContent>
+        </Card>
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className="text-2xl font-bold text-amber-600">{vfAt75} V</div>
+            <div className="text-xs text-gray-500">Extrapolated Vf@75°C</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Vf vs Temperature Linear Fit */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Zap className="h-4 w-4 text-amber-500" />
+              Vf vs Temperature – Linear Regression
+            </CardTitle>
+            <CardDescription className="text-xs">
+              Vf = {regression.slope.toFixed(5)}×T + {regression.intercept.toFixed(4)} | R² = {regression.r2.toFixed(4)} | Slope ≈ {(regression.slope * 1000).toFixed(1)} mV/°C
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={280}>
+              <ScatterChart>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis
+                  dataKey="temp" type="number" domain={[20, 80]} name="Temperature"
+                  label={{ value: "Temperature (°C)", position: "insideBottom", offset: -5, fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <YAxis
+                  dataKey="vf" type="number" domain={["auto", "auto"]} name="Vf"
+                  label={{ value: "Vf (V)", angle: -90, position: "insideLeft", fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <Tooltip
+                  formatter={(v: number, name: string) => [
+                    name === "vfFit" ? `${v.toFixed(4)} V (fit)` : `${v.toFixed(4)} V`,
+                    name === "vfFit" ? "Regression" : "Measured"
+                  ]}
+                  labelFormatter={(l) => `${l}°C`}
+                />
+                <Legend wrapperStyle={{ fontSize: 10 }} />
+                <Scatter name="Measured Vf" data={scatterPoints} dataKey="vf" fill="#f59e0b" />
+                <Scatter
+                  name="Linear Fit"
+                  data={regressionLine}
+                  dataKey="vfFit"
+                  fill="none"
+                  line={{ stroke: "#ef4444", strokeWidth: 2, strokeDasharray: "6 3" }}
+                  legendType="line"
+                  shape={() => null}
+                />
+                <ReferenceLine
+                  x={75} stroke="#8b5cf6" strokeDasharray="4 2"
+                  label={{ value: "75°C extrap.", fill: "#8b5cf6", fontSize: 9, position: "top" }}
+                />
+              </ScatterChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        {/* Stress Test 75°C / 1hr */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Thermometer className="h-4 w-4 text-red-500" />
+              Stress Test – Junction Temp during Isc Loading at 75°C Ambient
+            </CardTitle>
+            <CardDescription className="text-xs">
+              1-hour test | Pass: Tj ≤ Tj,max ({tjMax}°C)
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={280}>
+              <LineChart data={stressChartData}>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis
+                  dataKey="time" type="number"
+                  label={{ value: "Time (min)", position: "insideBottom", offset: -5, fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <YAxis
+                  domain={[60, 85]}
+                  label={{ value: "Tj (°C)", angle: -90, position: "insideLeft", fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <Tooltip formatter={(v: number) => [`${v}°C`, ""]} labelFormatter={l => `${l} min`} />
+                <Legend wrapperStyle={{ fontSize: 10 }} />
+                <ReferenceLine
+                  y={tjMax} stroke="#ef4444" strokeDasharray="5 3" strokeWidth={2}
+                  label={{ value: `Tj,max = ${tjMax}°C`, position: "right", fill: "#ef4444", fontSize: 9 }}
+                />
+                {Object.keys(MODULE_COLORS).map(mod => (
+                  <Line
+                    key={mod} type="monotone" dataKey={mod} name={mod}
+                    stroke={MODULE_COLORS[mod]} strokeWidth={2} dot={{ r: 2 }}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Regression Statistics Card */}
+      <Card className="bg-amber-50 border-amber-200">
+        <CardContent className="pt-4 pb-3">
+          <div className="text-xs text-amber-800 space-y-1">
+            <span className="font-semibold">Linear Regression Summary (Vf = a×T + b):</span>
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mt-2">
+              <div>
+                <div className="text-gray-500">Slope (a)</div>
+                <div className="font-mono font-bold">{regression.slope.toFixed(5)} V/°C</div>
+              </div>
+              <div>
+                <div className="text-gray-500">Intercept (b)</div>
+                <div className="font-mono font-bold">{regression.intercept.toFixed(4)} V</div>
+              </div>
+              <div>
+                <div className="text-gray-500">R²</div>
+                <div className="font-mono font-bold">{regression.r2.toFixed(4)}</div>
+              </div>
+              <div>
+                <div className="text-gray-500">Temp Coefficient</div>
+                <div className="font-mono font-bold">{(regression.slope * 1000).toFixed(1)} mV/°C</div>
+              </div>
+              <div>
+                <div className="text-gray-500">Vf @ 75°C (extrap.)</div>
+                <div className="font-mono font-bold">{vfAt75} V</div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Per-diode detail table */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">Per-Diode Vf Measurements (V)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr>
+                  <th className="border p-1.5 bg-gray-50 text-left">Module</th>
+                  <th className="border p-1.5 bg-gray-50 text-left">Diode</th>
+                  <th className="border p-1.5 bg-gray-50 text-center">25°C</th>
+                  <th className="border p-1.5 bg-gray-50 text-center">40°C</th>
+                  <th className="border p-1.5 bg-gray-50 text-center">55°C</th>
+                  <th className="border p-1.5 bg-gray-50 text-center">70°C</th>
+                  <th className="border p-1.5 bg-gray-50 text-center">ΔVf/°C (mV)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {["MOD-A01", "MOD-A02", "MOD-A03"].map(mod =>
+                  [1, 2, 3].map(di => {
+                    const diodeData = vfData.filter(d => d.moduleId === mod && d.diodeIdx === di)
+                    const vf25 = diodeData.find(d => d.temp === 25)?.vf ?? 0
+                    const vf70 = diodeData.find(d => d.temp === 70)?.vf ?? 0
+                    const slope = ((vf70 - vf25) / 45 * 1000).toFixed(1)
+                    return (
+                      <tr key={`${mod}-${di}`}>
+                        <td className="border p-1.5 font-mono">{mod}</td>
+                        <td className="border p-1.5 text-center">D{di}</td>
+                        {[25, 40, 55, 70].map(t => {
+                          const v = diodeData.find(d => d.temp === t)?.vf
+                          return (
+                            <td key={t} className="border p-1.5 text-center font-mono">
+                              {v?.toFixed(4) ?? "—"}
+                            </td>
+                          )
+                        })}
+                        <td className="border p-1.5 text-center font-mono font-bold">{slope}</td>
+                      </tr>
+                    )
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/data-analysis/DataAnalysisPage.tsx
+++ b/components/data-analysis/DataAnalysisPage.tsx
@@ -66,6 +66,9 @@ import { IVCurveTab } from "./IVCurveTab"
 import { NMOTCalculator } from "./NMOTCalculator"
 import { PeelTestAnalysis } from "./PeelTestAnalysis"
 import { WeatherQA } from "./WeatherQA"
+import { BypassDiodeAnalysis } from "./BypassDiodeAnalysis"
+import { LeTIDAnalysis } from "./LeTIDAnalysis"
+import { GelContentAnalysis } from "./GelContentAnalysis"
 import TestProtocolsManager from "@/components/lims/TestProtocolsManager"
 import {
   generateMockData,
@@ -473,6 +476,14 @@ export default function DataAnalysisPage() {
           <TabsTrigger value="bypass" className="text-xs">
             <Zap className="mr-1 h-3 w-3" />
             Bypass Diode
+          </TabsTrigger>
+          <TabsTrigger value="letid" className="text-xs">
+            <Activity className="mr-1 h-3 w-3" />
+            LeTID
+          </TabsTrigger>
+          <TabsTrigger value="gelcontent" className="text-xs">
+            <FlaskConical className="mr-1 h-3 w-3" />
+            Gel Content
           </TabsTrigger>
           <TabsTrigger value="bifaciality" className="text-xs">
             <BarChart3 className="mr-1 h-3 w-3" />
@@ -1632,90 +1643,32 @@ export default function DataAnalysisPage() {
           <div className="mb-4">
             <h2 className="text-lg font-semibold">Bypass Diode Test Analysis</h2>
             <p className="text-sm text-muted-foreground">
-              Forward/reverse I-V characteristics, thermal evaluation per IEC 61215 MQT 18 &amp; IEC 61730 MST 22
+              Vf vs Temperature linear fit, stress test thermal evaluation per IEC 61215 MQT 18 &amp; IEC 61730 MST 22
             </p>
           </div>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            {[
-              { label: "Diodes Tested", value: "24", sub: "8 modules × 3 diodes", color: "text-blue-600" },
-              { label: "Pass Rate", value: "95.8%", sub: "23/24 passed", color: "text-green-600" },
-              { label: "Avg Forward Vf", value: "0.52 V", sub: "at 5A test current", color: "text-purple-600" },
-              { label: "Max Junction Temp", value: "68°C", sub: "below Tj,max = 80°C", color: "text-amber-600" },
-            ].map(({ label, value, sub, color }) => (
-              <Card key={label}>
-                <CardContent className="pt-4 pb-3">
-                  <CardDescription>{label}</CardDescription>
-                  <div className={`text-2xl font-bold ${color}`}>{value}</div>
-                  <p className="text-xs text-muted-foreground">{sub}</p>
-                </CardContent>
-              </Card>
-            ))}
+          <BypassDiodeAnalysis />
+        </TabsContent>
+
+        {/* ===================== TAB: LeTID ===================== */}
+        <TabsContent value="letid" className="space-y-6">
+          <div className="mb-4">
+            <h2 className="text-lg font-semibold">LeTID Analysis</h2>
+            <p className="text-sm text-muted-foreground">
+              Light and elevated Temperature Induced Degradation per IEC TS 63342
+            </p>
           </div>
-          <div className="grid gap-6 md:grid-cols-2">
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm flex items-center gap-2">
-                  <Zap className="h-4 w-4 text-yellow-500" />
-                  Forward I-V Characteristics
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={220}>
-                  <LineChart data={[
-                    { v: 0.0, m1: 0.00, m2: 0.00, m3: 0.00 },
-                    { v: 0.1, m1: 0.01, m2: 0.01, m3: 0.01 },
-                    { v: 0.2, m1: 0.05, m2: 0.04, m3: 0.05 },
-                    { v: 0.3, m1: 0.20, m2: 0.18, m3: 0.22 },
-                    { v: 0.4, m1: 0.80, m2: 0.75, m3: 0.85 },
-                    { v: 0.45, m1: 1.80, m2: 1.70, m3: 1.95 },
-                    { v: 0.5, m1: 3.50, m2: 3.30, m3: 3.80 },
-                    { v: 0.52, m1: 5.00, m2: 4.80, m3: 5.20 },
-                    { v: 0.55, m1: 8.00, m2: 7.60, m3: 8.40 },
-                  ]}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="v" label={{ value: "Vf (V)", position: "insideBottom", offset: -5 }} tick={{ fontSize: 10 }} />
-                    <YAxis label={{ value: "If (A)", angle: -90, position: "insideLeft" }} tick={{ fontSize: 10 }} />
-                    <Tooltip formatter={(v: number) => `${v.toFixed(2)} A`} />
-                    <Legend />
-                    <Line type="monotone" dataKey="m1" name="Module 1" stroke="#3b82f6" dot={false} strokeWidth={2} />
-                    <Line type="monotone" dataKey="m2" name="Module 2" stroke="#22c55e" dot={false} strokeWidth={2} />
-                    <Line type="monotone" dataKey="m3" name="Module 3" stroke="#f59e0b" dot={false} strokeWidth={2} />
-                  </LineChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm flex items-center gap-2">
-                  <Thermometer className="h-4 w-4 text-red-500" />
-                  Bypass Diode Thermal Results (MQT 18)
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-3">
-                  {[
-                    { module: "SMP-2026-041", d1: 52, d2: 55, d3: 50, status: "PASS" },
-                    { module: "SMP-2026-042", d1: 61, d2: 68, d3: 63, status: "PASS" },
-                    { module: "SMP-2026-043", d1: 58, d2: 57, d3: 59, status: "PASS" },
-                    { module: "SMP-2026-044", d1: 65, d2: 82, d3: 64, status: "FAIL" },
-                  ].map(({ module, d1, d2, d3, status }) => (
-                    <div key={module} className="flex items-center gap-3 p-2 rounded-lg border">
-                      <span className="text-xs font-mono w-28">{module}</span>
-                      <div className="flex gap-2 flex-1">
-                        {[d1, d2, d3].map((t, i) => (
-                          <span key={i} className={`text-xs px-2 py-0.5 rounded font-mono ${t > 80 ? 'bg-red-100 text-red-700' : t > 70 ? 'bg-amber-100 text-amber-700' : 'bg-green-100 text-green-700'}`}>
-                            D{i + 1}: {t}°C
-                          </span>
-                        ))}
-                      </div>
-                      <span className={`text-xs font-bold ${status === 'PASS' ? 'text-green-600' : 'text-red-600'}`}>{status}</span>
-                    </div>
-                  ))}
-                </div>
-                <p className="text-xs text-muted-foreground mt-2">Tj,max = 80°C (rated). Values after 1h Isc loading + 10 thermal cycles.</p>
-              </CardContent>
-            </Card>
+          <LeTIDAnalysis />
+        </TabsContent>
+
+        {/* ===================== TAB: GEL CONTENT ===================== */}
+        <TabsContent value="gelcontent" className="space-y-6">
+          <div className="mb-4">
+            <h2 className="text-lg font-semibold">Gel Content &amp; Degree of Cure Analysis</h2>
+            <p className="text-sm text-muted-foreground">
+              Soxhlet extraction &amp; DSC methods per IEC 62788-1-6
+            </p>
           </div>
+          <GelContentAnalysis />
         </TabsContent>
 
         {/* ===================== TAB: BIFACIALITY ===================== */}

--- a/components/data-analysis/GelContentAnalysis.tsx
+++ b/components/data-analysis/GelContentAnalysis.tsx
@@ -1,0 +1,415 @@
+// @ts-nocheck
+"use client"
+
+import { useState, useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  ResponsiveContainer, BarChart, Bar, LineChart, Line,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine, Cell
+} from "recharts"
+import { FlaskConical, CheckCircle, XCircle, Beaker } from "lucide-react"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SoxhletSample {
+  sampleId: string
+  initialWeight: number  // g
+  driedWeight: number    // g
+  gelContent: number     // %
+}
+
+interface DSCSample {
+  sampleId: string
+  hTotal: number         // J/g total enthalpy (uncured)
+  hResidual: number      // J/g residual enthalpy (cured)
+  degreeOfCure: number   // %
+  tcUncured: number      // °C crystallization temp uncured
+  tcCured: number        // °C crystallization temp cured
+  gelContent: number     // % from Soxhlet for correlation
+}
+
+interface DSCThermogramPoint {
+  temperature: number
+  heatFlow: number
+}
+
+// ─── Sample Data ─────────────────────────────────────────────────────────────
+
+function generateSoxhletData(): SoxhletSample[] {
+  const samples: SoxhletSample[] = [
+    { sampleId: "GC-001", initialWeight: 0.5120, driedWeight: 0.4510, gelContent: 0 },
+    { sampleId: "GC-002", initialWeight: 0.4980, driedWeight: 0.4230, gelContent: 0 },
+    { sampleId: "GC-003", initialWeight: 0.5050, driedWeight: 0.4550, gelContent: 0 },
+    { sampleId: "GC-004", initialWeight: 0.5200, driedWeight: 0.4056, gelContent: 0 },
+    { sampleId: "GC-005", initialWeight: 0.4900, driedWeight: 0.4361, gelContent: 0 },
+    { sampleId: "GC-006", initialWeight: 0.5080, driedWeight: 0.4674, gelContent: 0 },
+  ]
+  // G% = (dried/initial)*100
+  return samples.map(s => ({
+    ...s,
+    gelContent: parseFloat(((s.driedWeight / s.initialWeight) * 100).toFixed(1))
+  }))
+}
+
+function generateDSCData(soxhletData: SoxhletSample[]): DSCSample[] {
+  return soxhletData.map((s, i) => {
+    const hTotal = 28 + Math.random() * 8 // J/g
+    // Degree of cure correlates with gel content
+    const degreeOfCure = s.gelContent * 0.95 + (Math.random() - 0.5) * 3
+    const hResidual = hTotal * (1 - degreeOfCure / 100)
+    return {
+      sampleId: s.sampleId,
+      hTotal: parseFloat(hTotal.toFixed(1)),
+      hResidual: parseFloat(hResidual.toFixed(1)),
+      degreeOfCure: parseFloat(degreeOfCure.toFixed(1)),
+      tcUncured: parseFloat((48 + Math.random() * 3).toFixed(1)),
+      tcCured: parseFloat((55 + Math.random() * 4 + (s.gelContent - 80) * 0.2).toFixed(1)),
+      gelContent: s.gelContent,
+    }
+  })
+}
+
+function generateDSCThermogram(): DSCThermogramPoint[] {
+  const points: DSCThermogramPoint[] = []
+  for (let t = 30; t <= 200; t += 1) {
+    let hf = 0
+    // Endothermic melting peak around 70°C (EVA)
+    hf += -2.5 * Math.exp(-Math.pow((t - 70) / 8, 2))
+    // Exothermic curing peak around 150°C
+    hf += 1.8 * Math.exp(-Math.pow((t - 150) / 12, 2))
+    // Baseline drift
+    hf += 0.002 * (t - 100)
+    // Noise
+    hf += (Math.random() - 0.5) * 0.08
+    points.push({ temperature: t, heatFlow: parseFloat(hf.toFixed(4)) })
+  }
+  return points
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function GelContentAnalysis() {
+  const soxhletData = useMemo(() => generateSoxhletData(), [])
+  const dscData = useMemo(() => generateDSCData(soxhletData), [soxhletData])
+  const thermogramData = useMemo(() => generateDSCThermogram(), [])
+
+  const MIN_GEL = 65  // JPL criteria
+  const TARGET_GEL = 80  // recommended
+
+  // Soxhlet statistics
+  const gelValues = soxhletData.map(s => s.gelContent)
+  const avgGel = parseFloat((gelValues.reduce((a, b) => a + b, 0) / gelValues.length).toFixed(1))
+  const minGel = Math.min(...gelValues)
+  const maxGel = Math.max(...gelValues)
+  const stdDev = parseFloat(Math.sqrt(gelValues.reduce((s, v) => s + Math.pow(v - avgGel, 2), 0) / gelValues.length).toFixed(2))
+  const passCountSoxhlet = gelValues.filter(v => v >= MIN_GEL).length
+
+  // DSC statistics
+  const avgDOC = parseFloat((dscData.reduce((s, d) => s + d.degreeOfCure, 0) / dscData.length).toFixed(1))
+  const passCountDSC = dscData.filter(d => d.degreeOfCure >= 60).length
+
+  const overallPassRate = parseFloat(((passCountSoxhlet / soxhletData.length) * 100).toFixed(1))
+
+  // Bar chart data for Soxhlet
+  const barData = soxhletData.map(s => ({
+    id: s.sampleId.replace("GC-", ""),
+    gelContent: s.gelContent,
+    pass: s.gelContent >= MIN_GEL,
+  }))
+
+  // Comparison table data
+  const comparisonData = soxhletData.map((s, i) => ({
+    sampleId: s.sampleId,
+    soxhletGel: s.gelContent,
+    dscDOC: dscData[i].degreeOfCure,
+    hTotal: dscData[i].hTotal,
+    hResidual: dscData[i].hResidual,
+    tcShift: parseFloat((dscData[i].tcCured - dscData[i].tcUncured).toFixed(1)),
+  }))
+
+  return (
+    <div className="space-y-4">
+      {/* Header badges */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Badge variant="outline" className="border-amber-300 text-amber-700">IEC 62788-1-6</Badge>
+        <Badge variant="outline" className="border-blue-300 text-blue-700">Gel Content / Degree of Cure</Badge>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className="text-2xl font-bold text-blue-600">{avgGel}%</div>
+            <div className="text-xs text-gray-500">Avg Gel Content</div>
+          </CardContent>
+        </Card>
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className="text-2xl font-bold text-purple-600">{avgDOC}%</div>
+            <div className="text-xs text-gray-500">Avg Degree of Cure</div>
+          </CardContent>
+        </Card>
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className="text-2xl font-bold">{soxhletData.length}</div>
+            <div className="text-xs text-gray-500">Samples Tested</div>
+          </CardContent>
+        </Card>
+        <Card className="text-center py-2">
+          <CardContent className="pt-3 pb-0">
+            <div className={`text-2xl font-bold ${overallPassRate >= 90 ? "text-green-600" : "text-amber-600"}`}>
+              {overallPassRate}%
+            </div>
+            <div className="text-xs text-gray-500">Pass Rate</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ─── Soxhlet Extraction Section ─── */}
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <FlaskConical className="h-4 w-4 text-amber-500" />
+          Soxhlet Extraction (Weight Method)
+        </h3>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Input Table */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Sample Weights & Gel Content</CardTitle>
+            <CardDescription className="text-xs">G% = (Dried Weight / Initial Weight) × 100</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr>
+                    <th className="border p-1.5 bg-gray-50 text-left">Sample ID</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">Initial (g)</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">Dried (g)</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">G%</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {soxhletData.map(s => (
+                    <tr key={s.sampleId}>
+                      <td className="border p-1.5 font-mono">{s.sampleId}</td>
+                      <td className="border p-1.5 text-center font-mono">{s.initialWeight.toFixed(4)}</td>
+                      <td className="border p-1.5 text-center font-mono">{s.driedWeight.toFixed(4)}</td>
+                      <td className="border p-1.5 text-center font-mono font-bold">{s.gelContent}%</td>
+                      <td className="border p-1.5 text-center">
+                        {s.gelContent >= TARGET_GEL ? (
+                          <Badge className="bg-green-100 text-green-700 text-xs">PASS</Badge>
+                        ) : s.gelContent >= MIN_GEL ? (
+                          <Badge className="bg-amber-100 text-amber-700 text-xs">MARGINAL</Badge>
+                        ) : (
+                          <Badge className="bg-red-100 text-red-700 text-xs">FAIL</Badge>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-2 grid grid-cols-4 gap-2 text-xs">
+              <div className="p-2 bg-gray-50 rounded">
+                <div className="text-gray-500">Average</div>
+                <div className="font-bold font-mono">{avgGel}%</div>
+              </div>
+              <div className="p-2 bg-gray-50 rounded">
+                <div className="text-gray-500">Min</div>
+                <div className="font-bold font-mono">{minGel.toFixed(1)}%</div>
+              </div>
+              <div className="p-2 bg-gray-50 rounded">
+                <div className="text-gray-500">Max</div>
+                <div className="font-bold font-mono">{maxGel.toFixed(1)}%</div>
+              </div>
+              <div className="p-2 bg-gray-50 rounded">
+                <div className="text-gray-500">Std Dev</div>
+                <div className="font-bold font-mono">{stdDev}%</div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Gel Content Bar Chart */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Gel Content per Sample</CardTitle>
+            <CardDescription className="text-xs">
+              Min threshold: {MIN_GEL}% (JPL) | Target: {TARGET_GEL}%
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={280}>
+              <BarChart data={barData}>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis dataKey="id" tick={{ fontSize: 10 }}
+                  label={{ value: "Sample", position: "insideBottom", offset: -5, fontSize: 10 }} />
+                <YAxis domain={[50, 100]} tick={{ fontSize: 10 }}
+                  label={{ value: "Gel Content (%)", angle: -90, position: "insideLeft", fontSize: 9 }} />
+                <Tooltip formatter={(v: number) => [`${v}%`, "Gel Content"]} />
+                <ReferenceLine y={MIN_GEL} stroke="#ef4444" strokeDasharray="5 3" strokeWidth={2}
+                  label={{ value: `Min ${MIN_GEL}%`, position: "right", fill: "#ef4444", fontSize: 9 }} />
+                <ReferenceLine y={TARGET_GEL} stroke="#22c55e" strokeDasharray="5 3" strokeWidth={2}
+                  label={{ value: `Target ${TARGET_GEL}%`, position: "right", fill: "#22c55e", fontSize: 9 }} />
+                <Bar dataKey="gelContent" name="Gel Content (%)" maxBarSize={40}>
+                  {barData.map((d, i) => (
+                    <Cell key={i}
+                      fill={d.gelContent >= TARGET_GEL ? "#86efac" : d.gelContent >= MIN_GEL ? "#fcd34d" : "#fca5a5"}
+                      stroke={d.gelContent >= TARGET_GEL ? "#22c55e" : d.gelContent >= MIN_GEL ? "#f59e0b" : "#ef4444"}
+                      strokeWidth={1}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ─── DSC Method Section ─── */}
+      <div className="space-y-1 pt-2">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <Beaker className="h-4 w-4 text-blue-500" />
+          DSC Method (Differential Scanning Calorimetry)
+        </h3>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* DSC Enthalpy Table */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Residual Enthalpy – Degree of Cure</CardTitle>
+            <CardDescription className="text-xs">
+              DOC = (1 − H_residual / H_total) × 100
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr>
+                    <th className="border p-1.5 bg-gray-50 text-left">Sample</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">H_total (J/g)</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">H_residual (J/g)</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">DOC (%)</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">Tc_uncured</th>
+                    <th className="border p-1.5 bg-gray-50 text-center">Tc_cured</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dscData.map(d => (
+                    <tr key={d.sampleId}>
+                      <td className="border p-1.5 font-mono">{d.sampleId}</td>
+                      <td className="border p-1.5 text-center font-mono">{d.hTotal}</td>
+                      <td className="border p-1.5 text-center font-mono">{d.hResidual}</td>
+                      <td className="border p-1.5 text-center font-mono font-bold">{d.degreeOfCure}%</td>
+                      <td className="border p-1.5 text-center font-mono">{d.tcUncured}°C</td>
+                      <td className="border p-1.5 text-center font-mono">{d.tcCured}°C</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* DSC Thermogram */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">DSC Thermogram</CardTitle>
+            <CardDescription className="text-xs">
+              Heat Flow vs Temperature – Endothermic (down) / Exothermic (up)
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={280}>
+              <LineChart data={thermogramData}>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis dataKey="temperature" type="number"
+                  label={{ value: "Temperature (°C)", position: "insideBottom", offset: -5, fontSize: 10 }}
+                  tick={{ fontSize: 10 }} />
+                <YAxis
+                  label={{ value: "Heat Flow (W/g)", angle: -90, position: "insideLeft", fontSize: 9 }}
+                  tick={{ fontSize: 10 }} />
+                <Tooltip formatter={(v: number) => [`${v.toFixed(4)} W/g`, "Heat Flow"]}
+                  labelFormatter={l => `${l}°C`} />
+                <ReferenceLine y={0} stroke="#9ca3af" strokeDasharray="2 2" />
+                <Line type="monotone" dataKey="heatFlow" stroke="#8b5cf6" dot={false} strokeWidth={1.5} name="Heat Flow" />
+              </LineChart>
+            </ResponsiveContainer>
+            <div className="flex justify-center gap-6 mt-1 text-xs text-gray-500">
+              <span>↓ Endothermic (~70°C EVA melt)</span>
+              <span>↑ Exothermic (~150°C curing)</span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ─── Comparison Section ─── */}
+      <div className="space-y-1 pt-2">
+        <h3 className="text-sm font-semibold">Soxhlet vs DSC – Comparison</h3>
+      </div>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr>
+                  <th className="border p-1.5 bg-gray-50 text-left">Sample</th>
+                  <th className="border p-1.5 bg-amber-50 text-center" colSpan={1}>Soxhlet G%</th>
+                  <th className="border p-1.5 bg-blue-50 text-center" colSpan={1}>DSC DOC%</th>
+                  <th className="border p-1.5 bg-blue-50 text-center">H_total (J/g)</th>
+                  <th className="border p-1.5 bg-blue-50 text-center">H_residual (J/g)</th>
+                  <th className="border p-1.5 bg-purple-50 text-center">ΔTc (°C)</th>
+                  <th className="border p-1.5 bg-gray-50 text-center">Correlation</th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparisonData.map(d => {
+                  const diff = Math.abs(d.soxhletGel - d.dscDOC)
+                  return (
+                    <tr key={d.sampleId}>
+                      <td className="border p-1.5 font-mono">{d.sampleId}</td>
+                      <td className="border p-1.5 text-center font-mono font-bold bg-amber-50">{d.soxhletGel}%</td>
+                      <td className="border p-1.5 text-center font-mono font-bold bg-blue-50">{d.dscDOC}%</td>
+                      <td className="border p-1.5 text-center font-mono">{d.hTotal}</td>
+                      <td className="border p-1.5 text-center font-mono">{d.hResidual}</td>
+                      <td className="border p-1.5 text-center font-mono">{d.tcShift > 0 ? "+" : ""}{d.tcShift}</td>
+                      <td className="border p-1.5 text-center">
+                        {diff < 5 ? (
+                          <Badge className="bg-green-100 text-green-700 text-xs">Good</Badge>
+                        ) : (
+                          <Badge className="bg-amber-100 text-amber-700 text-xs">Review</Badge>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Reference */}
+      <Card className="bg-amber-50 border-amber-200">
+        <CardContent className="pt-4 pb-3">
+          <div className="text-xs text-amber-800">
+            <span className="font-semibold">IEC 62788-1-6 – Gel Content & Degree of Cure:</span>{" "}
+            <strong>Soxhlet extraction:</strong> G% = (dried weight / initial weight) × 100.
+            Pass: ≥65% (JPL 5101-161 criteria). Recommended: ≥80%.
+            <strong> DSC method:</strong> Degree of cure = (1 − H_residual/H_total) × 100.
+            Crystallization temp shift (Tc_cured − Tc_uncured) indicates crosslink density.
+            Both methods should correlate within ±5%.
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/data-analysis/LeTIDAnalysis.tsx
+++ b/components/data-analysis/LeTIDAnalysis.tsx
@@ -1,0 +1,344 @@
+// @ts-nocheck
+"use client"
+
+import { useState, useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  ResponsiveContainer, AreaChart, Area, LineChart, Line,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine
+} from "recharts"
+import { AlertTriangle, CheckCircle, Zap, Thermometer, Activity } from "lucide-react"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface VdarkPoint {
+  hours: number
+  vdark: number
+}
+
+interface PmaxDegradationPoint {
+  hours: number
+  perc: number
+  topcon: number
+  hjt: number
+}
+
+// ─── Sample Data ─────────────────────────────────────────────────────────────
+
+function generateVdarkData(): VdarkPoint[] {
+  // PERC module: U-shaped curve – degradation then regeneration
+  // Vdark drops from ~38.5V to minimum ~37.2V around 200h, then recovers to ~38.3V
+  const data: VdarkPoint[] = []
+  for (let h = 0; h <= 500; h += 10) {
+    let vdark: number
+    if (h <= 200) {
+      // Degradation phase: exponential decay
+      vdark = 38.5 - 1.3 * (1 - Math.exp(-h / 80))
+    } else {
+      // Regeneration phase: recovery
+      vdark = 37.2 + 1.1 * (1 - Math.exp(-(h - 200) / 120))
+    }
+    vdark += (Math.random() - 0.5) * 0.05
+    data.push({ hours: h, vdark: parseFloat(vdark.toFixed(3)) })
+  }
+  return data
+}
+
+function generatePmaxDegradation(): PmaxDegradationPoint[] {
+  const data: PmaxDegradationPoint[] = []
+  for (let h = 0; h <= 500; h += 10) {
+    // PERC: drops to ~95% then recovers to ~97%
+    let perc: number
+    if (h <= 200) {
+      perc = 100 - 5 * (1 - Math.exp(-h / 80))
+    } else {
+      perc = 95 + 2 * (1 - Math.exp(-(h - 200) / 120))
+    }
+
+    // TOPCon: drops to ~99% then recovers to ~99.5%
+    let topcon: number
+    if (h <= 150) {
+      topcon = 100 - 1 * (1 - Math.exp(-h / 60))
+    } else {
+      topcon = 99 + 0.5 * (1 - Math.exp(-(h - 150) / 100))
+    }
+
+    // HJT: minimal degradation
+    const hjt = 100 - 0.5 * (1 - Math.exp(-h / 100))
+
+    data.push({
+      hours: h,
+      perc: parseFloat((perc + (Math.random() - 0.5) * 0.3).toFixed(2)),
+      topcon: parseFloat((topcon + (Math.random() - 0.5) * 0.15).toFixed(2)),
+      hjt: parseFloat((hjt + (Math.random() - 0.5) * 0.1).toFixed(2)),
+    })
+  }
+  return data
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function LeTIDAnalysis() {
+  const [isc, setIsc] = useState(11.2)
+  const [impp, setImpp] = useState(10.5)
+  const [testTemp, setTestTemp] = useState(75)
+
+  const vdarkData = useMemo(() => generateVdarkData(), [])
+  const pmaxData = useMemo(() => generatePmaxDegradation(), [])
+
+  // Find minimum Vdark point
+  const minVdark = useMemo(() => {
+    let min = vdarkData[0]
+    vdarkData.forEach(d => { if (d.vdark < min.vdark) min = d })
+    return min
+  }, [vdarkData])
+
+  // Check regeneration: minimum held for 10 consecutive hours (1 data point = 10h)
+  const regenerationDetected = useMemo(() => {
+    const minIdx = vdarkData.findIndex(d => d.hours === minVdark.hours)
+    if (minIdx < 0 || minIdx >= vdarkData.length - 1) return false
+    // Check if next point is higher (regeneration started)
+    return vdarkData[minIdx + 1]?.vdark > minVdark.vdark
+  }, [vdarkData, minVdark])
+
+  // Power supply calculator
+  const iInject = parseFloat((isc - impp).toFixed(2))
+  const estVoltage = parseFloat((0.7 * 60).toFixed(1)) // ~60 cells × 0.7V forward bias
+  const estPower = parseFloat((iInject * estVoltage).toFixed(1))
+  const durationPerCycle = 162
+  const totalDuration = durationPerCycle * 2
+
+  // Gradient zones for Vdark chart
+  const vdarkWithZone = useMemo(() =>
+    vdarkData.map(d => ({
+      ...d,
+      degradation: d.hours <= minVdark.hours ? d.vdark : undefined,
+      regeneration: d.hours >= minVdark.hours ? d.vdark : undefined,
+    })), [vdarkData, minVdark])
+
+  return (
+    <div className="space-y-4">
+      {/* Header badges */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Badge variant="outline" className="border-amber-300 text-amber-700">IEC TS 63342</Badge>
+        <Badge variant="outline" className="border-blue-300 text-blue-700">LeTID / LID Testing</Badge>
+        {regenerationDetected && (
+          <Badge className="bg-green-100 text-green-700 border-green-300">
+            <CheckCircle className="h-3 w-3 mr-1" />
+            Regeneration Detected
+          </Badge>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Dark Voltage vs Time */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Activity className="h-4 w-4 text-amber-500" />
+              Dark Voltage (Vdark) vs Time
+            </CardTitle>
+            <CardDescription className="text-xs">
+              U-shaped curve: degradation → minimum → regeneration | Min at {minVdark.hours}h: {minVdark.vdark.toFixed(3)}V
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={280}>
+              <AreaChart data={vdarkWithZone}>
+                <defs>
+                  <linearGradient id="gradDegradation" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#ef4444" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#ef4444" stopOpacity={0.05} />
+                  </linearGradient>
+                  <linearGradient id="gradRegeneration" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0.05} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis
+                  dataKey="hours" type="number"
+                  label={{ value: "Time (hours)", position: "insideBottom", offset: -5, fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <YAxis
+                  domain={[36.8, 38.8]}
+                  label={{ value: "Vdark (V)", angle: -90, position: "insideLeft", fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <Tooltip formatter={(v: number) => [`${v?.toFixed(3) ?? "—"} V`, ""]} labelFormatter={l => `${l}h`} />
+                <Area
+                  type="monotone" dataKey="degradation" name="Degradation"
+                  stroke="#ef4444" fill="url(#gradDegradation)" strokeWidth={2}
+                  dot={false} connectNulls={false}
+                />
+                <Area
+                  type="monotone" dataKey="regeneration" name="Regeneration"
+                  stroke="#22c55e" fill="url(#gradRegeneration)" strokeWidth={2}
+                  dot={false} connectNulls={false}
+                />
+                <ReferenceLine
+                  x={minVdark.hours} stroke="#f59e0b" strokeDasharray="4 2"
+                  label={{ value: `Min: ${minVdark.vdark.toFixed(3)}V`, fill: "#f59e0b", fontSize: 9, position: "top" }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        {/* Power Supply Settings Calculator */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Zap className="h-4 w-4 text-blue-500" />
+              Power Supply Settings Calculator
+            </CardTitle>
+            <CardDescription className="text-xs">
+              Calculate injection current and estimated power for LeTID testing
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-4 mb-4">
+              <div className="space-y-1">
+                <Label className="text-xs">Isc (A)</Label>
+                <Input type="number" step="0.1" value={isc} onChange={e => setIsc(+e.target.value)} className="h-7 text-xs" />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Impp (A)</Label>
+                <Input type="number" step="0.1" value={impp} onChange={e => setImpp(+e.target.value)} className="h-7 text-xs" />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Test Temperature (°C)</Label>
+                <Input type="number" step="5" value={testTemp} onChange={e => setTestTemp(+e.target.value)} className="h-7 text-xs" />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                { label: "I_inject (Isc − Impp)", value: `${iInject} A`, color: "border-l-blue-500" },
+                { label: "Estimated Voltage", value: `${estVoltage} V`, color: "border-l-green-500" },
+                { label: "Estimated Power", value: `${estPower} W`, color: "border-l-purple-500" },
+                { label: "Duration (162h × 2 cycles)", value: `${totalDuration} h`, color: "border-l-amber-500" },
+              ].map(({ label, value, color }) => (
+                <div key={label} className={`p-3 bg-gray-50 rounded border-l-4 ${color}`}>
+                  <div className="text-xs text-gray-500">{label}</div>
+                  <div className="text-lg font-bold font-mono">{value}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-3 p-2 bg-amber-50 rounded text-xs text-amber-700">
+              <AlertTriangle className="h-3 w-3 inline mr-1" />
+              Test per IEC TS 63342: Forward bias current injection at {testTemp}°C for {durationPerCycle}h per cycle, 2 cycles total.
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Pmax Degradation Chart */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Thermometer className="h-4 w-4 text-red-500" />
+              Pmax Degradation by Cell Technology
+            </CardTitle>
+            <CardDescription className="text-xs">
+              Pmax/Pmax_initial (%) vs hours | PERC: −5%, TOPCon: −1%, HJT: −0.5%
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={280}>
+              <LineChart data={pmaxData}>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis
+                  dataKey="hours" type="number"
+                  label={{ value: "Time (hours)", position: "insideBottom", offset: -5, fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <YAxis
+                  domain={[93, 101]}
+                  label={{ value: "Pmax/Pmax₀ (%)", angle: -90, position: "insideLeft", fontSize: 10 }}
+                  tick={{ fontSize: 10 }}
+                />
+                <Tooltip
+                  formatter={(v: number, name: string) => [`${v.toFixed(2)}%`, name]}
+                  labelFormatter={l => `${l}h`}
+                />
+                <Legend wrapperStyle={{ fontSize: 10 }} />
+                <ReferenceLine y={95} stroke="#ef4444" strokeDasharray="5 3"
+                  label={{ value: "−5% limit", fill: "#ef4444", fontSize: 9 }} />
+                <Line type="monotone" dataKey="perc" name="PERC" stroke="#ef4444" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="topcon" name="TOPCon" stroke="#3b82f6" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="hjt" name="HJT" stroke="#22c55e" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        {/* LeTID State Diagram */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">LeTID State Diagram</CardTitle>
+            <CardDescription className="text-xs">
+              Three-state model: State A (inactive) → State B (active/degraded) → State C (regenerated)
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex items-center justify-center">
+            <svg viewBox="0 0 500 200" className="w-full max-w-md" style={{ height: 200 }}>
+              {/* State A */}
+              <rect x="20" y="60" width="120" height="80" rx="12" fill="#dbeafe" stroke="#3b82f6" strokeWidth="2" />
+              <text x="80" y="95" textAnchor="middle" className="text-sm" fill="#1e40af" fontWeight="bold" fontSize="14">State A</text>
+              <text x="80" y="115" textAnchor="middle" fill="#3b82f6" fontSize="10">Inactive</text>
+              <text x="80" y="130" textAnchor="middle" fill="#3b82f6" fontSize="9">(Pre-degradation)</text>
+
+              {/* Arrow A→B */}
+              <line x1="140" y1="100" x2="180" y2="100" stroke="#f59e0b" strokeWidth="2" markerEnd="url(#arrowAmber)" />
+              <text x="160" y="90" textAnchor="middle" fill="#f59e0b" fontSize="9" fontWeight="bold">Light/Heat</text>
+
+              {/* State B */}
+              <rect x="185" y="60" width="120" height="80" rx="12" fill="#fef3c7" stroke="#f59e0b" strokeWidth="2" />
+              <text x="245" y="95" textAnchor="middle" fill="#92400e" fontWeight="bold" fontSize="14">State B</text>
+              <text x="245" y="115" textAnchor="middle" fill="#f59e0b" fontSize="10">Active</text>
+              <text x="245" y="130" textAnchor="middle" fill="#f59e0b" fontSize="9">(Degraded)</text>
+
+              {/* Arrow B→C */}
+              <line x1="305" y1="100" x2="345" y2="100" stroke="#22c55e" strokeWidth="2" markerEnd="url(#arrowGreen)" />
+              <text x="325" y="90" textAnchor="middle" fill="#22c55e" fontSize="9" fontWeight="bold">Regeneration</text>
+
+              {/* State C */}
+              <rect x="350" y="60" width="120" height="80" rx="12" fill="#dcfce7" stroke="#22c55e" strokeWidth="2" />
+              <text x="410" y="95" textAnchor="middle" fill="#166534" fontWeight="bold" fontSize="14">State C</text>
+              <text x="410" y="115" textAnchor="middle" fill="#22c55e" fontSize="10">Regenerated</text>
+              <text x="410" y="130" textAnchor="middle" fill="#22c55e" fontSize="9">(Stable)</text>
+
+              {/* Arrow markers */}
+              <defs>
+                <marker id="arrowAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="#f59e0b" />
+                </marker>
+                <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="#22c55e" />
+                </marker>
+              </defs>
+            </svg>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Reference */}
+      <Card className="bg-blue-50 border-blue-200">
+        <CardContent className="pt-4 pb-3">
+          <div className="text-xs text-blue-800">
+            <span className="font-semibold">IEC TS 63342 – LeTID Testing:</span>{" "}
+            Light and elevated Temperature Induced Degradation. Forward-bias current injection
+            (I = Isc − Impp) at 75°C or 85°C. Two cycles of 162h each. Monitor Pmax and Vdark.
+            Degradation limit: PERC ≤ 5%, TOPCon ≤ 2%, HJT ≤ 1%.
+            Regeneration confirmed when minimum Vdark is sustained for ≥10 consecutive hours.
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
- BypassDiodeAnalysis: Vf vs Temperature linear regression chart with R², slope, intercept; stress test 75°C/1hr junction temp chart; per-diode measurement table; extrapolated Vf@75°C
- LeTIDAnalysis (IEC TS 63342): Dark voltage vs time U-shaped curve with degradation/regeneration regions; power supply settings calculator; Pmax degradation by cell technology (PERC/TOPCon/HJT); SVG state diagram (A→B→C)
- GelContentAnalysis (IEC 62788-1-6): Soxhlet extraction weight method with sample table and bar chart (65% min / 80% target); DSC residual enthalpy degree of cure; thermogram chart; Soxhlet vs DSC comparison table
- Wired all 3 into DataAnalysisPage.tsx with new tab triggers

https://claude.ai/code/session_01S2Lqom99zPdsbxwfcXESGz