### PR TITLE
Add IEC compliance details and dosage criteria across 4 modules

### DIFF
--- a/app/(dashboard)/chamber-config/page.tsx
+++ b/app/(dashboard)/chamber-config/page.tsx
@@ -17,7 +17,14 @@ import {
   Clock,
   IndianRupee,
   Box,
+  Info,
+  AlertCircle,
+  FileText,
+  CheckCircle2,
 } from "lucide-react";
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow
+} from "@/components/ui/table";
 
 const testTypeIcons: Record<string, React.ReactNode> = {
   TC: <Thermometer className="h-5 w-5 text-red-500" />,
@@ -192,6 +199,166 @@ export default function ChamberConfigPage() {
           ))}
         </div>
       </div>
+
+      {/* IEC Standard Chamber Requirements */}
+      <div>
+        <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
+          <FileText className="h-5 w-5 text-primary" />
+          IEC Standard Environmental Chamber Requirements
+        </h2>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {/* Damp Heat */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <Droplets className="h-5 w-5 text-cyan-500" />
+                <CardTitle className="text-base">Damp Heat (DH) — IEC 61215 MQT 13</CardTitle>
+              </div>
+              <CardDescription>Accelerated moisture ingress and corrosion test</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableBody>
+                  <TableRow><TableCell className="text-xs font-medium">Temperature</TableCell><TableCell className="text-xs">85°C ± 2°C</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Relative Humidity</TableCell><TableCell className="text-xs">85% ± 5% RH</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Duration</TableCell><TableCell className="text-xs">1000 hours (standard) / 2000 hours (extended)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Ramp Rate</TableCell><TableCell className="text-xs">Stabilize within 2 hours of reaching setpoint</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Sample Loading</TableCell><TableCell className="text-xs">Module tilted 5-90° from vertical, air circulation maintained</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Measurements</TableCell><TableCell className="text-xs">Pmax, insulation resistance, visual inspection pre/post</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Pass Criteria</TableCell><TableCell className="text-xs font-semibold text-green-700">Pmax degradation ≤ 5%, wet leakage current pass, no major visual defects</TableCell></TableRow>
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          {/* Thermal Cycling */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <Thermometer className="h-5 w-5 text-red-500" />
+                <CardTitle className="text-base">Thermal Cycling (TC) — IEC 61215 MQT 11</CardTitle>
+              </div>
+              <CardDescription>Thermal fatigue and solder joint reliability test</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableBody>
+                  <TableRow><TableCell className="text-xs font-medium">Low Temperature</TableCell><TableCell className="text-xs">-40°C ± 2°C</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">High Temperature</TableCell><TableCell className="text-xs">85°C ± 2°C</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Ramp Rate</TableCell><TableCell className="text-xs">≤ 100°C/hr maximum (typically 80-100°C/hr)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Dwell Time</TableCell><TableCell className="text-xs">≥ 10 minutes at each extreme</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Cycle Count</TableCell><TableCell className="text-xs">200 cycles (TC200) or 50 cycles (TC50 per sequence)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Cycle Duration</TableCell><TableCell className="text-xs">~3 hours per cycle (with ramp and dwell)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Current Injection</TableCell><TableCell className="text-xs">Isc applied during test (IEC 61215:2021)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Pass Criteria</TableCell><TableCell className="text-xs font-semibold text-green-700">Pmax degradation ≤ 5%, no open circuits, visual pass</TableCell></TableRow>
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          {/* Humidity Freeze */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <Snowflake className="h-5 w-5 text-blue-500" />
+                <CardTitle className="text-base">Humidity Freeze (HF) — IEC 61215 MQT 12</CardTitle>
+              </div>
+              <CardDescription>Thermal shock with moisture penetration test</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableBody>
+                  <TableRow><TableCell className="text-xs font-medium">High Temperature</TableCell><TableCell className="text-xs">85°C ± 2°C</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">High Humidity</TableCell><TableCell className="text-xs">85% ± 5% RH (at high temp phase)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Low Temperature</TableCell><TableCell className="text-xs">-40°C ± 2°C (no humidity control)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Ramp Rate</TableCell><TableCell className="text-xs">≤ 100°C/hr maximum</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Dwell at 85°C/85%RH</TableCell><TableCell className="text-xs">≥ 20 hours</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Dwell at -40°C</TableCell><TableCell className="text-xs">≥ 30 minutes (minimum)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Cycle Count</TableCell><TableCell className="text-xs">10 cycles (HF10)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Pass Criteria</TableCell><TableCell className="text-xs font-semibold text-green-700">Pmax degradation ≤ 5%, wet leakage pass, no delamination</TableCell></TableRow>
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          {/* UV Preconditioning */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <Sun className="h-5 w-5 text-yellow-500" />
+                <CardTitle className="text-base">UV Preconditioning — IEC 61215 MQT 10</CardTitle>
+              </div>
+              <CardDescription>UV degradation screening of encapsulant and backsheet</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableBody>
+                  <TableRow><TableCell className="text-xs font-medium">Wavelength Range</TableCell><TableCell className="text-xs">280 - 400 nm (UVA + UVB)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Total UV Dose</TableCell><TableCell className="text-xs">15 kWh/m² UVA (280-320nm) + 5 kWh/m² UVB (320-400nm)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">UV Irradiance</TableCell><TableCell className="text-xs">100-250 W/m² (adjustable, measured at test plane)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Module Temperature</TableCell><TableCell className="text-xs">60°C ± 5°C (module surface)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Duration</TableCell><TableCell className="text-xs">~120-200 hours (depending on UV intensity)</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Uniformity</TableCell><TableCell className="text-xs">UV irradiance uniformity ≤ ± 15% across test plane</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Measurement</TableCell><TableCell className="text-xs">UV radiometer calibrated per ISO 17025, traceable</TableCell></TableRow>
+                  <TableRow><TableCell className="text-xs font-medium">Pass Criteria</TableCell><TableCell className="text-xs font-semibold text-green-700">No delamination, yellowing index ΔYI ≤ 5, Pmax ≤ 5% degradation</TableCell></TableRow>
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Chamber Tolerance Summary */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-amber-500" />
+            Chamber Tolerance Summary (IEC 61215:2021 / IEC 61730:2023)
+          </CardTitle>
+          <CardDescription>
+            Critical control parameters and their allowable tolerances for accredited testing
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-xs">Test Type</TableHead>
+                <TableHead className="text-xs">Parameter</TableHead>
+                <TableHead className="text-xs">Setpoint</TableHead>
+                <TableHead className="text-xs">Tolerance</TableHead>
+                <TableHead className="text-xs">Measurement Instrument</TableHead>
+                <TableHead className="text-xs">Cal. Interval</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[
+                { test: "DH", param: "Temperature", setpoint: "85°C", tolerance: "± 2°C", instrument: "Calibrated PT100 (Class A)", cal: "12 months" },
+                { test: "DH", param: "Humidity", setpoint: "85% RH", tolerance: "± 5% RH", instrument: "Capacitive RH sensor (± 1.5%)", cal: "12 months" },
+                { test: "TC", param: "Low Temp", setpoint: "-40°C", tolerance: "± 2°C", instrument: "Calibrated PT100 (Class A)", cal: "12 months" },
+                { test: "TC", param: "High Temp", setpoint: "85°C", tolerance: "± 2°C", instrument: "Calibrated PT100 (Class A)", cal: "12 months" },
+                { test: "TC", param: "Ramp Rate", setpoint: "100°C/hr", tolerance: "max (not exceeded)", instrument: "PLC ramp controller + PT100", cal: "12 months" },
+                { test: "HF", param: "Low Temp", setpoint: "-40°C", tolerance: "± 2°C", instrument: "Calibrated PT100 (Class A)", cal: "12 months" },
+                { test: "HF", param: "High Temp", setpoint: "85°C", tolerance: "± 2°C", instrument: "Calibrated PT100 (Class A)", cal: "12 months" },
+                { test: "HF", param: "Humidity", setpoint: "85% RH", tolerance: "± 5% RH", instrument: "Capacitive RH sensor (± 1.5%)", cal: "12 months" },
+                { test: "UV", param: "Wavelength", setpoint: "280-400nm", tolerance: "per lamp specification", instrument: "UV radiometer (ISO 17025)", cal: "12 months" },
+                { test: "UV", param: "Total Dose", setpoint: "15 kWh/m²", tolerance: "Measured (integrated)", instrument: "UV integrating radiometer", cal: "12 months" },
+                { test: "UV", param: "Module Temp", setpoint: "60°C", tolerance: "± 5°C", instrument: "Thermocouple / PT100", cal: "12 months" },
+              ].map((row, i) => (
+                <TableRow key={i}>
+                  <TableCell><Badge variant="outline" className="text-xs">{row.test}</Badge></TableCell>
+                  <TableCell className="text-xs font-medium">{row.param}</TableCell>
+                  <TableCell className="text-xs font-mono">{row.setpoint}</TableCell>
+                  <TableCell className="text-xs font-mono font-semibold text-primary">{row.tolerance}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground">{row.instrument}</TableCell>
+                  <TableCell className="text-xs">{row.cal}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/(dashboard)/sun-simulator/page.tsx
+++ b/app/(dashboard)/sun-simulator/page.tsx
@@ -163,6 +163,188 @@ export default function SunSimulatorPage() {
           </Table>
         </CardContent>
       </Card>
+
+      {/* IEC 60904-9 Ed.3 Detailed Classification */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">IEC 60904-9 Ed.3 Classification Details</CardTitle>
+          <CardDescription>
+            Comprehensive classification parameters for solar simulator performance assessment
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Spectral Match */}
+          <div className="space-y-2">
+            <h3 className="font-semibold text-sm flex items-center gap-2">
+              Spectral Match (IEC 60904-9 Clause 5.2)
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Ratio of measured spectral irradiance to AM1.5G reference spectrum (IEC 60904-3) in 6 wavelength intervals.
+              Each interval ratio must fall within classification limits. The overall spectral classification is determined by the worst interval.
+            </p>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="text-xs">Wavelength Interval (nm)</TableHead>
+                  <TableHead className="text-xs text-center">AM1.5G Fraction (%)</TableHead>
+                  <TableHead className="text-xs text-center">A+ Range</TableHead>
+                  <TableHead className="text-xs text-center">A Range</TableHead>
+                  <TableHead className="text-xs text-center">B Range</TableHead>
+                  <TableHead className="text-xs text-center">C Range</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {[
+                  { interval: "400 - 500", fraction: "18.4", aPlus: "0.875 - 1.125", a: "0.75 - 1.25", b: "0.6 - 1.4", c: "0.4 - 2.0" },
+                  { interval: "500 - 600", fraction: "19.9", aPlus: "0.875 - 1.125", a: "0.75 - 1.25", b: "0.6 - 1.4", c: "0.4 - 2.0" },
+                  { interval: "600 - 700", fraction: "18.4", aPlus: "0.875 - 1.125", a: "0.75 - 1.25", b: "0.6 - 1.4", c: "0.4 - 2.0" },
+                  { interval: "700 - 800", fraction: "14.9", aPlus: "0.875 - 1.125", a: "0.75 - 1.25", b: "0.6 - 1.4", c: "0.4 - 2.0" },
+                  { interval: "800 - 900", fraction: "12.5", aPlus: "0.875 - 1.125", a: "0.75 - 1.25", b: "0.6 - 1.4", c: "0.4 - 2.0" },
+                  { interval: "900 - 1100", fraction: "15.9", aPlus: "0.875 - 1.125", a: "0.75 - 1.25", b: "0.6 - 1.4", c: "0.4 - 2.0" },
+                ].map((row) => (
+                  <TableRow key={row.interval}>
+                    <TableCell className="text-xs font-mono">{row.interval}</TableCell>
+                    <TableCell className="text-xs text-center">{row.fraction}</TableCell>
+                    <TableCell className="text-xs text-center text-emerald-700">{row.aPlus}</TableCell>
+                    <TableCell className="text-xs text-center text-green-700">{row.a}</TableCell>
+                    <TableCell className="text-xs text-center text-yellow-700">{row.b}</TableCell>
+                    <TableCell className="text-xs text-center text-orange-700">{row.c}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Spatial Non-Uniformity */}
+          <div className="space-y-2">
+            <h3 className="font-semibold text-sm">Spatial Non-Uniformity of Irradiance (Clause 5.3)</h3>
+            <p className="text-sm text-muted-foreground">
+              Measured across the test plane using a matrix of at least 64 positions (8×8 grid).
+              Non-uniformity = (Emax - Emin) / (Emax + Emin) × 100%.
+              Measurement area must match or exceed the DUT area.
+            </p>
+            <div className="grid grid-cols-4 gap-3 text-center">
+              {[
+                { grade: "A+", value: "≤ 1%", color: "bg-emerald-50 border-emerald-200 text-emerald-800" },
+                { grade: "A", value: "≤ 2%", color: "bg-green-50 border-green-200 text-green-800" },
+                { grade: "B", value: "≤ 5%", color: "bg-yellow-50 border-yellow-200 text-yellow-800" },
+                { grade: "C", value: "≤ 10%", color: "bg-orange-50 border-orange-200 text-orange-800" },
+              ].map((g) => (
+                <div key={g.grade} className={`p-3 rounded-lg border ${g.color}`}>
+                  <div className="text-lg font-bold">{g.grade}</div>
+                  <div className="text-sm font-mono">{g.value}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Temporal Instability */}
+          <div className="space-y-2">
+            <h3 className="font-semibold text-sm">Temporal Instability of Irradiance (Clause 5.4)</h3>
+            <p className="text-sm text-muted-foreground">
+              Divided into Short-Term Instability (STI) during I-V sweep and Long-Term Instability (LTI) over the measurement period.
+              STI = (Emax - Emin) / (Emax + Emin) × 100% during one I-V sweep.
+              LTI = variation over multiple consecutive measurements (typically 10 minutes).
+            </p>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <h4 className="text-xs font-semibold mb-2">Short-Term Instability (STI)</h4>
+                <div className="grid grid-cols-4 gap-2 text-center">
+                  {[
+                    { grade: "A+", value: "≤ 0.5%", color: "bg-emerald-50 text-emerald-800" },
+                    { grade: "A", value: "≤ 2%", color: "bg-green-50 text-green-800" },
+                    { grade: "B", value: "≤ 5%", color: "bg-yellow-50 text-yellow-800" },
+                    { grade: "C", value: "≤ 10%", color: "bg-orange-50 text-orange-800" },
+                  ].map((g) => (
+                    <div key={g.grade} className={`p-2 rounded ${g.color}`}>
+                      <div className="text-sm font-bold">{g.grade}</div>
+                      <div className="text-xs font-mono">{g.value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <h4 className="text-xs font-semibold mb-2">Long-Term Instability (LTI)</h4>
+                <div className="grid grid-cols-4 gap-2 text-center">
+                  {[
+                    { grade: "A+", value: "≤ 1%", color: "bg-emerald-50 text-emerald-800" },
+                    { grade: "A", value: "≤ 2%", color: "bg-green-50 text-green-800" },
+                    { grade: "B", value: "≤ 5%", color: "bg-yellow-50 text-yellow-800" },
+                    { grade: "C", value: "≤ 10%", color: "bg-orange-50 text-orange-800" },
+                  ].map((g) => (
+                    <div key={g.grade} className={`p-2 rounded ${g.color}`}>
+                      <div className="text-sm font-bold">{g.grade}</div>
+                      <div className="text-xs font-mono">{g.value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Calibration Requirements */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Calibration Requirements</CardTitle>
+          <CardDescription>IEC 60904-2 reference device and calibration protocol requirements</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-3">
+              <h3 className="font-semibold text-sm">Calibration Protocol</h3>
+              <div className="space-y-2">
+                {[
+                  { item: "Calibration Frequency", value: "Annual recalibration or after any lamp/optics change" },
+                  { item: "Reference Standard", value: "IEC 60904-2 compliant reference cell with WPVS calibration" },
+                  { item: "Traceability", value: "Traceable to WPVS (World PV Scale) via primary calibration laboratory" },
+                  { item: "Spectral Measurement", value: "IEC 60904-7 spectroradiometer, 300-1200nm, ≤ 5nm resolution" },
+                  { item: "Uniformity Mapping", value: "Minimum 64 points (8×8 grid) across test plane, ≤ 50mm spacing" },
+                  { item: "Temperature Control", value: "Reference cell temperature 25°C ± 2°C during calibration" },
+                  { item: "Irradiance Level", value: "1000 W/m² ± 2% (STC condition)" },
+                  { item: "Documentation", value: "Certificate with classification, uncertainty budget, and validity period" },
+                ].map((req) => (
+                  <div key={req.item} className="flex items-start gap-2 text-sm">
+                    <Badge variant="outline" className="text-xs shrink-0 mt-0.5">{req.item}</Badge>
+                    <span className="text-muted-foreground">{req.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-3">
+              <h3 className="font-semibold text-sm">Reference Cell Specifications</h3>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-xs">Parameter</TableHead>
+                    <TableHead className="text-xs">Requirement</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {[
+                    { param: "Cell Technology", value: "Mono-Si (matched to DUT technology preferred)" },
+                    { param: "Active Area", value: "2×2 cm (minimum), 4 cm² typical" },
+                    { param: "Calibration Source", value: "WPVS-calibrated (PTB, NREL, AIST, ISE, ESTI)" },
+                    { param: "Calibration Uncertainty", value: "≤ ± 1.0% (k=2) for Isc" },
+                    { param: "Temperature Sensor", value: "Pt100 / thermocouple bonded to rear surface" },
+                    { param: "Temperature Coefficient", value: "Known α(Isc) and β(Voc), typically α ≈ +0.05%/°C" },
+                    { param: "Spectral Response", value: "Measured per IEC 60904-8, matched to DUT SR" },
+                    { param: "Encapsulation", value: "Glass-encapsulated, hermetically sealed" },
+                    { param: "Connector", value: "4-wire Kelvin connection for low contact resistance" },
+                    { param: "Calibration Validity", value: "12 months (or per accreditation scope)" },
+                  ].map((row) => (
+                    <TableRow key={row.param}>
+                      <TableCell className="text-xs font-medium">{row.param}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">{row.value}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/app/(dashboard)/uncertainty/page.tsx
+++ b/app/(dashboard)/uncertainty/page.tsx
@@ -100,7 +100,7 @@ function FinancialImpactAnalysis({ uncertaintyPct }: { uncertaintyPct: number })
 
 export default function UncertaintyDashboard() {
   const [selectedType, setSelectedType] = useState<TestUncertaintyType>("flasher_stc");
-  const [activeTab, setActiveTab] = useState<"overview" | "fishbone" | "simulators" | "cals" | "financial">("overview");
+  const [activeTab, setActiveTab] = useState<"overview" | "fishbone" | "simulators" | "cals" | "financial" | "gum">("overview");
   const [adminMode, setAdminMode] = useState(false);
 
   const config = TEST_UNCERTAINTY_CONFIGS[selectedType];
@@ -239,6 +239,7 @@ export default function UncertaintyDashboard() {
           { key: "simulators", label: "Sun Simulators (14)" },
           { key: "cals", label: "Cal. Laboratories (8)" },
           { key: "financial", label: "Financial Impact" },
+          { key: "gum", label: "GUM Components" },
         ].map((tab) => (
           <button
             key={tab.key}
@@ -391,6 +392,226 @@ export default function UncertaintyDashboard() {
       {activeTab === "financial" && (
         <FinancialImpactAnalysis uncertaintyPct={avgUncertainty} />
       )}
+
+{activeTab === "gum" && (
+  <div className="space-y-6">
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">GUM-Based Uncertainty Components</CardTitle>
+        <CardDescription>
+          Measurement uncertainty sources per JCGM 100:2008 (GUM) for IEC 61215 / IEC 60904 test methods.
+          Type A = statistical analysis of repeated measurements. Type B = other evaluation (certificates, specs, experience).
+        </CardDescription>
+      </CardHeader>
+    </Card>
+
+    {/* STC Flash Test Uncertainty */}
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">STC Flash Test (IEC 60904-1 / IEC 60891)</CardTitle>
+        <CardDescription className="text-xs">Pmax, Isc, Voc, FF measurement at 1000 W/m², 25°C, AM1.5G</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="bg-gray-100 border-b">
+              <th className="text-left p-2 font-semibold">Uncertainty Source</th>
+              <th className="text-center p-2 font-semibold">Type</th>
+              <th className="text-center p-2 font-semibold">Distribution</th>
+              <th className="text-center p-2 font-semibold">Typical Value</th>
+              <th className="text-center p-2 font-semibold">Divisor</th>
+              <th className="text-center p-2 font-semibold">u(xi) %</th>
+              <th className="text-center p-2 font-semibold">% Contribution</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              { source: "Reference cell calibration (Isc)", type: "B", dist: "Normal", value: "±0.8%", divisor: "2", uxi: "0.40", contrib: "~45%" },
+              { source: "Spatial non-uniformity of irradiance", type: "B", dist: "Rectangular", value: "±0.5%", divisor: "√3", uxi: "0.29", contrib: "~12%" },
+              { source: "Spectral mismatch correction (M)", type: "B", dist: "Rectangular", value: "±0.5%", divisor: "√3", uxi: "0.29", contrib: "~12%" },
+              { source: "Temporal instability (STI + LTI)", type: "B", dist: "Rectangular", value: "±0.3%", divisor: "√3", uxi: "0.17", contrib: "~4%" },
+              { source: "Module temperature (±2°C × γ)", type: "B", dist: "Normal", value: "±0.9%", divisor: "2", uxi: "0.45", contrib: "~14%" },
+              { source: "DAQ / I-V tracer accuracy", type: "B", dist: "Rectangular", value: "±0.1%", divisor: "√3", uxi: "0.06", contrib: "~1%" },
+              { source: "Repeatability (10 sweeps)", type: "A", dist: "Normal", value: "±0.3%", divisor: "√n", uxi: "0.10", contrib: "~3%" },
+              { source: "I-V curve correction (IEC 60891)", type: "B", dist: "Normal", value: "±0.5%", divisor: "2", uxi: "0.25", contrib: "~9%" },
+            ].map((row, i) => (
+              <tr key={i} className={`border-b ${i % 2 === 0 ? "bg-white" : "bg-gray-50"}`}>
+                <td className="p-2">{row.source}</td>
+                <td className="p-2 text-center"><Badge variant={row.type === "A" ? "default" : "outline"} className="text-xs">{row.type}</Badge></td>
+                <td className="p-2 text-center">{row.dist}</td>
+                <td className="p-2 text-center font-mono">{row.value}</td>
+                <td className="p-2 text-center font-mono">{row.divisor}</td>
+                <td className="p-2 text-center font-mono font-semibold">{row.uxi}</td>
+                <td className="p-2 text-center">{row.contrib}</td>
+              </tr>
+            ))}
+            <tr className="bg-blue-50 font-semibold">
+              <td className="p-2" colSpan={5}>Combined Standard Uncertainty u(Pmax)</td>
+              <td className="p-2 text-center font-mono">0.75%</td>
+              <td className="p-2 text-center"></td>
+            </tr>
+            <tr className="bg-blue-100 font-bold">
+              <td className="p-2" colSpan={5}>Expanded Uncertainty U(Pmax) at k=2 (95.45%)</td>
+              <td className="p-2 text-center font-mono text-primary">±1.50%</td>
+              <td className="p-2 text-center"></td>
+            </tr>
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+
+    {/* Thermal Cycling Uncertainty */}
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Thermal Cycling / DH / HF (IEC 61215 MQT 11/12/13)</CardTitle>
+        <CardDescription className="text-xs">Uncertainty in Pmax degradation measurement after environmental tests</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="bg-gray-100 border-b">
+              <th className="text-left p-2 font-semibold">Uncertainty Source</th>
+              <th className="text-center p-2 font-semibold">Type</th>
+              <th className="text-center p-2 font-semibold">Distribution</th>
+              <th className="text-center p-2 font-semibold">Typical Value</th>
+              <th className="text-center p-2 font-semibold">u(xi) %</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              { source: "Pre-test Pmax measurement (flasher)", type: "B", dist: "Normal", value: "±1.50%", uxi: "0.75" },
+              { source: "Post-test Pmax measurement (flasher)", type: "B", dist: "Normal", value: "±1.50%", uxi: "0.75" },
+              { source: "Chamber temperature uniformity", type: "B", dist: "Rectangular", value: "±2°C", uxi: "0.15" },
+              { source: "Chamber temperature accuracy", type: "B", dist: "Normal", value: "±1°C", uxi: "0.10" },
+              { source: "Humidity accuracy (DH/HF only)", type: "B", dist: "Rectangular", value: "±3% RH", uxi: "0.20" },
+              { source: "Cycle count / timer accuracy", type: "B", dist: "Rectangular", value: "negligible", uxi: "0.01" },
+              { source: "Module stabilization (light soaking)", type: "B", dist: "Rectangular", value: "±0.5%", uxi: "0.29" },
+              { source: "Sample-to-sample variation", type: "A", dist: "Normal", value: "±1.0%", uxi: "0.58" },
+            ].map((row, i) => (
+              <tr key={i} className={`border-b ${i % 2 === 0 ? "bg-white" : "bg-gray-50"}`}>
+                <td className="p-2">{row.source}</td>
+                <td className="p-2 text-center"><Badge variant={row.type === "A" ? "default" : "outline"} className="text-xs">{row.type}</Badge></td>
+                <td className="p-2 text-center">{row.dist}</td>
+                <td className="p-2 text-center font-mono">{row.value}</td>
+                <td className="p-2 text-center font-mono font-semibold">{row.uxi}</td>
+              </tr>
+            ))}
+            <tr className="bg-blue-50 font-semibold">
+              <td className="p-2" colSpan={4}>Combined u(ΔPmax) = √(u²_pre + u²_post + u²_chamber + ...)</td>
+              <td className="p-2 text-center font-mono">1.25%</td>
+            </tr>
+            <tr className="bg-blue-100 font-bold">
+              <td className="p-2" colSpan={4}>Expanded U(ΔPmax) at k=2</td>
+              <td className="p-2 text-center font-mono text-primary">±2.50%</td>
+            </tr>
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+
+    {/* Insulation / Wet Leakage */}
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Insulation / Wet Leakage (IEC 61215 MQT 15 / IEC 61730 MST 16)</CardTitle>
+        <CardDescription className="text-xs">Uncertainty in leakage current and dielectric withstand testing</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="bg-gray-100 border-b">
+              <th className="text-left p-2 font-semibold">Uncertainty Source</th>
+              <th className="text-center p-2 font-semibold">Type</th>
+              <th className="text-center p-2 font-semibold">Typical Value</th>
+              <th className="text-center p-2 font-semibold">u(xi)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              { source: "HV power supply voltage accuracy", type: "B", value: "±1% of applied voltage", uxi: "±10V at 1000V" },
+              { source: "Leakage current meter accuracy", type: "B", value: "±2% of reading + 0.5 μA", uxi: "±0.5 μA" },
+              { source: "Water resistivity variation", type: "B", value: "3500 Ω·cm ± 500", uxi: "±14% on resistance" },
+              { source: "Water temperature", type: "B", value: "22°C ± 2°C", uxi: "affects resistivity" },
+              { source: "Contact area consistency", type: "B", value: "± 2% area variation", uxi: "±2% on current" },
+              { source: "Measurement repeatability", type: "A", value: "±5% of reading", uxi: "from 5 repeat measurements" },
+            ].map((row, i) => (
+              <tr key={i} className={`border-b ${i % 2 === 0 ? "bg-white" : "bg-gray-50"}`}>
+                <td className="p-2">{row.source}</td>
+                <td className="p-2 text-center"><Badge variant={row.type === "A" ? "default" : "outline"} className="text-xs">{row.type}</Badge></td>
+                <td className="p-2 text-center font-mono">{row.value}</td>
+                <td className="p-2 text-center font-mono font-semibold">{row.uxi}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+
+    {/* Temperature Coefficient */}
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Temperature Coefficients (IEC 60891 / IEC 61215 MQT 06)</CardTitle>
+        <CardDescription className="text-xs">Uncertainty in α(Isc), β(Voc), γ(Pmax) determination</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="bg-gray-100 border-b">
+              <th className="text-left p-2 font-semibold">Uncertainty Source</th>
+              <th className="text-center p-2 font-semibold">Type</th>
+              <th className="text-center p-2 font-semibold">Typical Value</th>
+              <th className="text-center p-2 font-semibold">u(xi)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              { source: "Temperature measurement (module surface)", type: "B", value: "±1°C across module", uxi: "0.58°C" },
+              { source: "Irradiance stability during T sweep", type: "B", value: "±1%", uxi: "0.58%" },
+              { source: "Linear regression fit (R²)", type: "A", value: "R² > 0.998 typically", uxi: "from residuals" },
+              { source: "Temperature range (25-75°C minimum)", type: "B", value: "≥ 50°C range", uxi: "range dependent" },
+              { source: "Isc, Voc, Pmax measurement at each T", type: "B", value: "per flasher budget", uxi: "~0.75% for Pmax" },
+              { source: "Number of temperature points", type: "A", value: "≥ 4 points recommended", uxi: "√n dependent" },
+            ].map((row, i) => (
+              <tr key={i} className={`border-b ${i % 2 === 0 ? "bg-white" : "bg-gray-50"}`}>
+                <td className="p-2">{row.source}</td>
+                <td className="p-2 text-center"><Badge variant={row.type === "A" ? "default" : "outline"} className="text-xs">{row.type}</Badge></td>
+                <td className="p-2 text-center font-mono">{row.value}</td>
+                <td className="p-2 text-center font-mono font-semibold">{row.uxi}</td>
+              </tr>
+            ))}
+            <tr className="bg-blue-50 font-semibold">
+              <td className="p-2" colSpan={3}>Typical expanded uncertainty U(γ) at k=2</td>
+              <td className="p-2 text-center font-mono text-primary">±5-10% of γ value</td>
+            </tr>
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+
+    {/* GUM Process Summary */}
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">GUM Evaluation Process (JCGM 100:2008)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+          {[
+            { step: "1", title: "Define Measurand", desc: "Identify the quantity to be measured (Pmax, Isc, Voc, etc.)" },
+            { step: "2", title: "Identify Sources", desc: "List all sources of uncertainty (equipment, environment, method, operator)" },
+            { step: "3", title: "Quantify Components", desc: "Evaluate Type A (statistical) and Type B (other) uncertainties for each source" },
+            { step: "4", title: "Combine (RSS)", desc: "Calculate combined standard uncertainty: uc = √Σ(ci·ui)² using sensitivity coefficients" },
+            { step: "5", title: "Expand (k=2)", desc: "Apply coverage factor k=2 for ~95.45% confidence: U = k × uc" },
+          ].map((s) => (
+            <div key={s.step} className="p-3 rounded-lg border bg-muted/30 text-center">
+              <div className="text-lg font-bold text-primary mb-1">Step {s.step}</div>
+              <div className="text-xs font-semibold mb-1">{s.title}</div>
+              <div className="text-xs text-muted-foreground">{s.desc}</div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+)}
     </div>
   );
 }

--- a/app/iec62915/page.tsx
+++ b/app/iec62915/page.tsx
@@ -16,7 +16,7 @@ import {
 import {
   Package, GitBranch, ClipboardList, Calendar, AlertTriangle, CheckCircle2,
   Clock, ChevronRight, Plus, Search, Download, FileText, Zap, Layers,
-  BarChart3, Target, ArrowRight, Info, Edit3, Wrench, Activity
+  BarChart3, Target, ArrowRight, Info, Edit3, Wrench, Activity, Shield
 } from "lucide-react"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -198,6 +198,106 @@ const GANTT_TASKS: GanttTask[] = [
   { id: "m3", name: "Milestone: CB Submission", type: "milestone", startDate: "2026-05-31", endDate: "2026-05-31", progress: 0, status: "not_started", dependencies: ["t8"] },
 ]
 
+// ─── Qualification Matrix Data ────────────────────────────────────────────────
+
+interface QualificationCriteria {
+  material: string
+  partType: string
+  applicableStandards: string[]
+  tests: {
+    testName: string
+    standard: string
+    dosage: string
+    duration: string
+    passCriteria: string
+    failCriteria: string
+  }[]
+}
+
+const BOM_QUALIFICATION_MATRIX: QualificationCriteria[] = [
+  {
+    material: "Encapsulant (EVA)",
+    partType: "encapsulant",
+    applicableStandards: ["IEC 61215", "IEC 62788-1-2", "IEC 62788-1-4", "IEC 62788-1-6"],
+    tests: [
+      { testName: "UV Preconditioning", standard: "IEC 61215 MQT 10", dosage: "15 kWh/m² (UVA 280-320nm) + 5 kWh/m² (UVB)", duration: "120-200 hours", passCriteria: "No delamination, discoloration ΔYI < 5", failCriteria: "Delamination, yellowing ΔYI ≥ 5, bubbles" },
+      { testName: "Gel Content (Cross-linking)", standard: "IEC 62788-1-2", dosage: "Soxhlet extraction in xylene, 24h", duration: "24 hours", passCriteria: "Gel content ≥ 65% (EVA)", failCriteria: "Gel content < 65%" },
+      { testName: "Volume Resistivity", standard: "IEC 62788-1-4", dosage: "500V DC applied, 23°C and 85°C/85%RH", duration: "1 min electrification", passCriteria: "≥ 1×10¹² Ω·cm (dry), ≥ 1×10¹⁰ Ω·cm (damp)", failCriteria: "Below threshold values" },
+      { testName: "Damp Heat Stability", standard: "IEC 61215 MQT 13", dosage: "85°C ± 2°C, 85% ± 5% RH", duration: "1000 hours", passCriteria: "Pmax degradation ≤ 5%, no delamination", failCriteria: "Pmax degradation > 5%, delamination" },
+      { testName: "Peel Strength (Adhesion)", standard: "IEC 62788-1-6", dosage: "180° peel test, 50mm/min", duration: "Per specimen", passCriteria: "≥ 40 N/cm (glass-EVA), ≥ 20 N/cm (EVA-backsheet)", failCriteria: "Below minimum adhesion values" },
+    ],
+  },
+  {
+    material: "Encapsulant (POE)",
+    partType: "encapsulant",
+    applicableStandards: ["IEC 61215", "IEC 62788-1-2", "IEC 62788-1-4"],
+    tests: [
+      { testName: "UV Preconditioning", standard: "IEC 61215 MQT 10", dosage: "15 kWh/m² (UVA) + 5 kWh/m² (UVB)", duration: "120-200 hours", passCriteria: "No delamination, ΔYI < 3 (better UV stability)", failCriteria: "Delamination, yellowing ΔYI ≥ 3" },
+      { testName: "Gel Content (Cross-linking)", standard: "IEC 62788-1-2", dosage: "Soxhlet extraction, 24h", duration: "24 hours", passCriteria: "Gel content ≥ 70% (POE)", failCriteria: "Gel content < 70%" },
+      { testName: "Volume Resistivity", standard: "IEC 62788-1-4", dosage: "500V DC, 23°C and 85°C/85%RH", duration: "1 min electrification", passCriteria: "≥ 1×10¹² Ω·cm (inherently higher than EVA)", failCriteria: "Below 1×10¹² Ω·cm" },
+      { testName: "Water Vapor Transmission", standard: "IEC 62788-1-4", dosage: "38°C, 90% RH", duration: "Until steady state", passCriteria: "≤ 5 g/m²/day", failCriteria: "> 5 g/m²/day" },
+    ],
+  },
+  {
+    material: "Backsheet (KPF/TPT/CPC)",
+    partType: "backsheet",
+    applicableStandards: ["IEC 61215", "IEC 62788-2", "IEC 61730"],
+    tests: [
+      { testName: "Partial Discharge", standard: "IEC 61730 MST 14", dosage: "1000V AC / 1500V DC system voltage", duration: "Per test sequence", passCriteria: "≤ 10 pC at 1000V", failCriteria: "> 10 pC partial discharge" },
+      { testName: "Water Vapor Transmission Rate", standard: "IEC 62788-2", dosage: "38°C, 90% RH (cup method)", duration: "Until steady state", passCriteria: "≤ 2 g/m²/day", failCriteria: "> 2 g/m²/day" },
+      { testName: "UV Exposure (Extended)", standard: "IEC 61215 / IEC 62788-7-2", dosage: "60 kWh/m² total UV dose (280-400nm)", duration: "500-800 hours", passCriteria: "No cracking, chalking, ΔE < 5, tensile retention > 50%", failCriteria: "Cracking, chalking, ΔE ≥ 5" },
+      { testName: "Dielectric Breakdown", standard: "IEC 61730 MST 16", dosage: "AC voltage ramp 500V/s", duration: "Until breakdown", passCriteria: "Breakdown voltage ≥ 18 kV/mm", failCriteria: "Breakdown < 18 kV/mm" },
+      { testName: "Thermal Cycling Adhesion", standard: "IEC 61215 MQT 11", dosage: "-40°C to 85°C, 200 cycles", duration: "~25 days", passCriteria: "Peel strength retention ≥ 80%", failCriteria: "Peel strength retention < 80%" },
+    ],
+  },
+  {
+    material: "Front Glass (Tempered Low-Iron)",
+    partType: "glass",
+    applicableStandards: ["IEC 61215", "IEC 61730", "EN 12150"],
+    tests: [
+      { testName: "Impact Test (Hail)", standard: "IEC 61215 MQT 17", dosage: "227g steel ball dropped from 1m height", duration: "11 impact points per module", passCriteria: "No breakage, Pmax degradation ≤ 5%", failCriteria: "Glass breakage or Pmax > 5% degradation" },
+      { testName: "Optical Transmittance", standard: "IEC 61215 / ISO 9050", dosage: "Spectrophotometer 350-1200nm", duration: "Per specimen", passCriteria: "≥ 90% weighted transmittance (350-1200nm)", failCriteria: "< 90% weighted transmittance" },
+      { testName: "Temper Stress (Fragmentation)", standard: "EN 12150-1", dosage: "Center punch fragmentation test", duration: "Per specimen", passCriteria: "≥ 40 fragments per 50×50mm area", failCriteria: "< 40 fragments (insufficient temper)" },
+      { testName: "Static Mechanical Load", standard: "IEC 61215 MQT 16", dosage: "2400 Pa front / 2400 Pa rear (or 5400 Pa)", duration: "1 hour each side × 3 cycles", passCriteria: "No breakage, Pmax ≤ 5% degradation", failCriteria: "Breakage or Pmax > 5%" },
+    ],
+  },
+  {
+    material: "Junction Box",
+    partType: "junction_box",
+    applicableStandards: ["IEC 62790", "IEC 61215", "IEC 61730"],
+    tests: [
+      { testName: "IP Rating (Ingress Protection)", standard: "IEC 62790 / IEC 60529", dosage: "IP67: 1m submersion 30min / IP68: per manufacturer", duration: "30 minutes (IP67)", passCriteria: "IP67 minimum (IP68 preferred), no water ingress", failCriteria: "Water ingress detected" },
+      { testName: "Bypass Diode Thermal Test", standard: "IEC 61215 MQT 18", dosage: "1.25× Isc for 1 hour, Tj measurement", duration: "1 hour per diode", passCriteria: "Tj(max) ≤ 150°C, no diode failure", failCriteria: "Tj > 150°C or diode failure/short" },
+      { testName: "Thermal Cycling (JB)", standard: "IEC 62790", dosage: "-40°C to 85°C, 200 cycles", duration: "~25 days", passCriteria: "No cracking, potting intact, contact resistance stable", failCriteria: "Cracking, potting failure, resistance increase > 5%" },
+      { testName: "Bypass Diode Functionality", standard: "IEC 61730 MST 22", dosage: "1.25× Isc reverse current, thermal imaging", duration: "Per test", passCriteria: "Diode conducts correctly, Tj ≤ 150°C", failCriteria: "Open/short circuit diode failure" },
+      { testName: "Pull-Out Test (Cable)", standard: "IEC 62790", dosage: "Axial pull force per cable spec", duration: "Per test", passCriteria: "≥ 60N pull-out force, no cable damage", failCriteria: "Cable pull-out or damage < 60N" },
+    ],
+  },
+  {
+    material: "Connectors (MC4 Type)",
+    partType: "other",
+    applicableStandards: ["IEC 62852", "EN 50521", "IEC 61730"],
+    tests: [
+      { testName: "Contact Resistance", standard: "IEC 62852", dosage: "4-wire measurement at rated current", duration: "Per connector pair", passCriteria: "< 0.5 mΩ contact resistance", failCriteria: "≥ 0.5 mΩ contact resistance" },
+      { testName: "Insulation Resistance", standard: "IEC 62852 / IEC 61730", dosage: "1000V DC (1500V system) between pins/housing", duration: "1 minute", passCriteria: "≥ 1000 MΩ (1 GΩ)", failCriteria: "< 1000 MΩ insulation resistance" },
+      { testName: "IP Rating", standard: "IEC 62852 / IEC 60529", dosage: "IP67 mated condition", duration: "30 minutes submersion", passCriteria: "IP67 — no water ingress when mated", failCriteria: "Water ingress detected" },
+      { testName: "Temperature Rise", standard: "IEC 62852", dosage: "Rated current for 6 hours", duration: "6 hours", passCriteria: "ΔT ≤ 30K above ambient", failCriteria: "ΔT > 30K temperature rise" },
+      { testName: "Locking Mechanism", standard: "IEC 62852", dosage: "Engagement/disengagement force test", duration: "Per test", passCriteria: "Requires tool for disconnection, ≥ 50N retention", failCriteria: "Disconnects without tool, < 50N retention" },
+    ],
+  },
+  {
+    material: "Frame (Aluminum 6005-T5)",
+    partType: "frame",
+    applicableStandards: ["IEC 61215", "IEC 61730", "ISO 2360"],
+    tests: [
+      { testName: "Static Mechanical Load", standard: "IEC 61215 MQT 16", dosage: "2400 Pa front + 2400 Pa rear load", duration: "1hr each side × 3 cycles", passCriteria: "No permanent deformation > 1mm, Pmax ≤ 5%", failCriteria: "Deformation > 1mm or Pmax > 5%" },
+      { testName: "Grounding Continuity", standard: "IEC 61730 MST 13", dosage: "2× rated short circuit current, min 2.5A", duration: "2 minutes", passCriteria: "Grounding resistance ≤ 0.1Ω", failCriteria: "Grounding resistance > 0.1Ω" },
+      { testName: "Anodizing Thickness", standard: "ISO 2360", dosage: "Eddy current measurement", duration: "Per specimen", passCriteria: "≥ 15 μm anodic layer (outdoor exposure)", failCriteria: "< 15 μm anodic coating" },
+      { testName: "Salt Mist Corrosion", standard: "IEC 61701 / ISO 9227", dosage: "5% NaCl, 35°C, pH 6.5-7.2", duration: "96 hours (severity level 6)", passCriteria: "No pitting, creepage ≤ 2mm from scribe", failCriteria: "Pitting or creepage > 2mm" },
+    ],
+  },
+]
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const statusColors = {
@@ -362,6 +462,9 @@ export default function IEC62915Page() {
           </TabsTrigger>
           <TabsTrigger value="scheduler" className="text-xs">
             <Calendar className="h-3 w-3 mr-1" /> Project Scheduler
+          </TabsTrigger>
+          <TabsTrigger value="qualification" className="text-xs">
+            <Shield className="h-3 w-3 mr-1" /> Qualification Matrix
           </TabsTrigger>
         </TabsList>
 
@@ -838,6 +941,117 @@ export default function IEC62915Page() {
               </CardContent>
             </Card>
           </div>
+        </TabsContent>
+
+        {/* ── QUALIFICATION MATRIX TAB ──────────────────────────── */}
+        <TabsContent value="qualification" className="space-y-4 mt-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Shield className="h-5 w-5 text-blue-600" />
+                IEC 62915 Material Qualification Matrix
+              </CardTitle>
+              <CardDescription className="text-sm">
+                Comprehensive pass/fail criteria per IEC test standards for all BOM material types.
+                Dosage, duration, and acceptance criteria per IEC 61215, IEC 61730, IEC 62788, and component standards.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+
+          {BOM_QUALIFICATION_MATRIX.map((mat) => (
+            <Card key={mat.material}>
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <Package className="h-4 w-4 text-primary" />
+                    {mat.material}
+                  </CardTitle>
+                  <div className="flex gap-1.5">
+                    {mat.applicableStandards.map((std) => (
+                      <Badge key={std} variant="outline" className="text-xs">{std}</Badge>
+                    ))}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="text-xs w-40">Test Name</TableHead>
+                      <TableHead className="text-xs w-32">Standard</TableHead>
+                      <TableHead className="text-xs">Dosage / Condition</TableHead>
+                      <TableHead className="text-xs w-28">Duration</TableHead>
+                      <TableHead className="text-xs">Pass Criteria</TableHead>
+                      <TableHead className="text-xs">Fail Criteria</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {mat.tests.map((test) => (
+                      <TableRow key={test.testName}>
+                        <TableCell className="text-xs font-medium">{test.testName}</TableCell>
+                        <TableCell>
+                          <Badge className="text-xs bg-blue-50 text-blue-700">{test.standard}</Badge>
+                        </TableCell>
+                        <TableCell className="text-xs">{test.dosage}</TableCell>
+                        <TableCell className="text-xs font-mono">{test.duration}</TableCell>
+                        <TableCell className="text-xs">
+                          <span className="flex items-center gap-1">
+                            <CheckCircle2 className="h-3 w-3 text-green-500 shrink-0" />
+                            {test.passCriteria}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          <span className="flex items-center gap-1">
+                            <AlertTriangle className="h-3 w-3 text-red-500 shrink-0" />
+                            {test.failCriteria}
+                          </span>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          ))}
+
+          {/* Quick Reference Summary */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <Info className="h-4 w-4 text-blue-500" />
+                Key Dosage Quick Reference
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {[
+                  { label: "EVA Gel Content", value: "≥ 65%", note: "Soxhlet extraction 24h in xylene" },
+                  { label: "POE Gel Content", value: "≥ 70%", note: "Higher cross-linking than EVA" },
+                  { label: "Volume Resistivity", value: "≥ 1×10¹² Ω·cm", note: "At 23°C, dry condition" },
+                  { label: "UV Preconditioning", value: "15 kWh/m²", note: "UVA dose per IEC 61215 MQT 10" },
+                  { label: "Backsheet UV Aging", value: "60 kWh/m²", note: "Extended UV per IEC 62788-7-2" },
+                  { label: "Backsheet WVTR", value: "≤ 2 g/m²/day", note: "38°C, 90% RH" },
+                  { label: "Partial Discharge", value: "≤ 10 pC", note: "At 1000V per IEC 61730" },
+                  { label: "Hail Impact", value: "227g @ 1m", note: "Steel ball, 11 impact points" },
+                  { label: "Glass Transmittance", value: "≥ 90%", note: "Weighted, 350-1200nm range" },
+                  { label: "JB Diode Tj Max", value: "≤ 150°C", note: "At 1.25× Isc for 1 hour" },
+                  { label: "JB IP Rating", value: "IP67/IP68", note: "30 min submersion minimum" },
+                  { label: "Connector Contact R", value: "< 0.5 mΩ", note: "4-wire measurement at rated I" },
+                  { label: "Connector Insulation", value: "1000V / 1 GΩ", note: "1500V system, 1 min test" },
+                  { label: "Connector IP Rating", value: "IP67", note: "Mated condition required" },
+                  { label: "Frame Ground R", value: "≤ 0.1 Ω", note: "At 2× Isc, min 2.5A for 2 min" },
+                ].map((item) => (
+                  <div key={item.label} className="flex items-start gap-2 p-2 rounded bg-muted/50 border">
+                    <Zap className="h-3 w-3 text-amber-500 mt-0.5 shrink-0" />
+                    <div>
+                      <div className="text-xs font-semibold">{item.label}: <span className="text-primary">{item.value}</span></div>
+                      <div className="text-xs text-muted-foreground">{item.note}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
- IEC 62915 BoM: Add qualification matrix tab with pass/fail criteria for encapsulant (EVA/POE), backsheet, glass, junction box, connectors, and frame including dosage values (UV 15kWh/m², gel content, volume resistivity, etc.)
- Sun Simulator: Add IEC 60904-9 Ed.3 spectral match wavelength intervals, spatial non-uniformity/temporal instability details, calibration protocol, and reference cell specifications
- Chamber Config: Add IEC standard requirements for DH (85±2°C/85±5%RH), TC (-40±2°C to 85±2°C, 100°C/hr max), HF, and UV (280-400nm, 15kWh/m²) with tolerance summary table
- Uncertainty: Add GUM-based uncertainty components tab covering STC flash test, TC/DH/HF, insulation/wet leakage, and temperature coefficients with typical values per IEC 61215/60904

https://claude.ai/code/session_01QKKfaPuS5cAP1jCzDtvy8H