### PR TITLE
Add RAG-powered chatbot with Pinecone vector search and streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,14 @@ CLAUDE_API_KEY="your-claude-api-key"
 
 # Roboflow API (for AI vision defect detection)
 ROBOFLOW_API_KEY="your-roboflow-api-key"
+
+# Anthropic API (for RAG chatbot - alternative to CLAUDE_API_KEY)
+ANTHROPIC_API_KEY="your-anthropic-api-key"
+
+# OpenAI API (for text embeddings in RAG pipeline)
+OPENAI_API_KEY="your-openai-api-key"
+
+# Pinecone Vector DB (for RAG knowledge base)
+PINECONE_API_KEY="your-pinecone-api-key"
+PINECONE_INDEX="your-pinecone-index-host-url"
+PINECONE_ENVIRONMENT="your-pinecone-environment"

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,603 @@
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// POST /api/chat – RAG-powered chat endpoint
+// Accepts { message, history }
+// 1. Embeds the user query and retrieves relevant chunks from Pinecone
+// 2. Passes context + history to Claude API for a grounded answer
+// 3. Streams the response back as text/event-stream
+// Falls back to Claude-only (no RAG) if Pinecone is not configured, and
+// further falls back to a rich demo/mock mode when no API keys are set.
+// ---------------------------------------------------------------------------
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+// ---- Pinecone helpers -----------------------------------------------------
+
+async function queryPinecone(
+  queryEmbedding: number[],
+  topK = 5
+): Promise<{ text: string; source: string; score: number }[]> {
+  const apiKey = process.env.PINECONE_API_KEY;
+  const indexHost = process.env.PINECONE_INDEX; // full host URL or index name
+  if (!apiKey || !indexHost) return [];
+
+  // Support both full host URL and index-name style
+  const host = indexHost.startsWith("http")
+    ? indexHost
+    : `https://${indexHost}`;
+
+  const res = await fetch(`${host}/query`, {
+    method: "POST",
+    headers: {
+      "Api-Key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      vector: queryEmbedding,
+      topK,
+      includeMetadata: true,
+    }),
+  });
+
+  if (!res.ok) {
+    console.error("Pinecone query error:", await res.text());
+    return [];
+  }
+
+  const data = await res.json();
+  return (data.matches ?? []).map(
+    (m: { metadata?: { text?: string; source?: string }; score?: number }) => ({
+      text: m.metadata?.text ?? "",
+      source: m.metadata?.source ?? "Unknown",
+      score: m.score ?? 0,
+    })
+  );
+}
+
+async function embedText(text: string): Promise<number[]> {
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey) return [];
+
+  const res = await fetch("https://api.openai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${openaiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "text-embedding-3-small",
+      input: text,
+    }),
+  });
+
+  if (!res.ok) {
+    console.error("OpenAI embedding error:", await res.text());
+    return [];
+  }
+
+  const data = await res.json();
+  return data.data?.[0]?.embedding ?? [];
+}
+
+// ---- Claude streaming helper -----------------------------------------------
+
+async function* streamClaude(
+  systemPrompt: string,
+  messages: { role: string; content: string }[]
+): AsyncGenerator<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
+  if (!apiKey) throw new Error("NO_API_KEY");
+
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      stream: true,
+      system: systemPrompt,
+      messages,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    console.error("Claude API error:", err);
+    throw new Error(`Claude API ${res.status}`);
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error("No response body");
+
+  const decoder = new TextDecoder();
+  let buf = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const payload = line.slice(6).trim();
+      if (payload === "[DONE]") return;
+      try {
+        const evt = JSON.parse(payload);
+        if (evt.type === "content_block_delta" && evt.delta?.text) {
+          yield evt.delta.text;
+        }
+      } catch {
+        // ignore non-JSON lines
+      }
+    }
+  }
+}
+
+// ---- Demo / mock streaming -------------------------------------------------
+
+const DEMO_RESPONSES: Record<string, { answer: string; sources: string[] }> = {
+  "iec 61215": {
+    answer: `## IEC 61215 - Design Qualification Test Sequence
+
+IEC 61215 requires the following comprehensive test sequence for crystalline silicon PV modules:
+
+### Initial Characterization
+- **MQT 01:** Visual Inspection (per IEC 61215-1, Clause 7)
+- **MQT 02:** Maximum Power Determination (I-V curve at STC: 1000 W/m², 25°C, AM1.5G)
+- **MQT 03:** Insulation Test (1000V + 2×Voc for ≥1 min)
+- **MQT 06:** Performance at STC and NMOT
+
+### Environmental & Stress Tests
+| Test | Condition | Duration/Cycles |
+|------|-----------|-----------------|
+| MQT 10 - UV Preconditioning | 280-400nm, 15 kWh/m² total UV dose | ~120 hours |
+| MQT 11 - Thermal Cycling | -40°C to +85°C with current injection | 200 cycles (TC200) |
+| MQT 12 - Humidity Freeze | -40°C to +85°C/85%RH | 10 cycles |
+| MQT 13 - Damp Heat | 85°C / 85% RH continuous | 1000 hours |
+| MQT 16 - Mechanical Load | 2400 Pa (front), 5400 Pa (front & rear) | 3 cycles each |
+| MQT 17 - Hail Test | 25mm ice balls at 23 m/s | 11 impact locations |
+| MQT 18 - Bypass Diode | Thermal test at 75°C for 1 hour | Per diode |
+| MQT 09 - Hot-spot | Worst-case shading, 5 hours | 5 hours |
+
+### Acceptance Criteria
+- Maximum power degradation: **< 5%** from initial value
+- No major visual defects per Table 1 of IEC 61215-1
+- Insulation resistance: **> 40 MΩ·m²**
+- Wet leakage current within limits
+- Minimum **8 modules** across **4 test sequences**
+
+### Test Sequence Groups (IEC 61215-2, Figure 2)
+- **Sequence A:** UV → TC50 → HF10 (2 modules)
+- **Sequence B:** TC200 (2 modules)
+- **Sequence C:** DH1000 (2 modules)
+- **Sequence D:** Outdoor exposure → additional TC/HF (2 modules)`,
+    sources: [
+      "IEC 61215-1:2021 §7-10",
+      "IEC 61215-2:2021 §4 (Test Sequences)",
+      "IEC 61215-1:2021 Table 1 (Visual Defects)",
+      "SOP-LAB-001 Rev.4",
+    ],
+  },
+  "qms audit": {
+    answer: `## ISO 17025 QMS Audit Checklist
+
+### 1. Structural Requirements (Clause 4-5)
+- [ ] Legal entity documentation current
+- [ ] Organizational chart with defined responsibilities
+- [ ] Impartiality policy documented and communicated
+- [ ] Confidentiality procedures in place
+- [ ] Management commitment evidence
+
+### 2. Resource Requirements (Clause 6)
+- [ ] **Personnel:** Competency records for all technical staff
+- [ ] **Personnel:** Training plans and effectiveness evaluation
+- [ ] **Facilities:** Environmental monitoring records (temp, humidity)
+- [ ] **Equipment:** Calibration certificates current (traceable to SI)
+- [ ] **Equipment:** Maintenance and intermediate check logs
+- [ ] **Metrological traceability:** Reference standards documentation
+
+### 3. Process Requirements (Clause 7)
+- [ ] **7.1:** Contract review records for each test request
+- [ ] **7.2:** Method validation/verification records
+- [ ] **7.3:** Sampling procedures documented
+- [ ] **7.4:** Sample handling and identification procedures
+- [ ] **7.5:** Technical records complete and retrievable
+- [ ] **7.6:** Measurement uncertainty budgets for all test methods
+- [ ] **7.7:** Quality control data (proficiency testing, inter-lab comparisons)
+- [ ] **7.8:** Report format compliant with Clause 7.8
+
+### 4. Management System (Clause 8)
+- [ ] Quality manual / documentation hierarchy
+- [ ] Document control procedure effective
+- [ ] Internal audit schedule and reports
+- [ ] Management review minutes (annual minimum)
+- [ ] CAPA log with effectiveness verification
+- [ ] Risk assessment and opportunity register
+
+### Key Focus Areas for Solar PV Labs
+- Uncertainty budgets for I-V measurements (IEC 60904-1)
+- Sun simulator classification records (IEC 60904-9)
+- Chamber calibration and uniformity surveys
+- Reference cell calibration chain (to WRR/SI)`,
+    sources: [
+      "ISO/IEC 17025:2017 §4-8",
+      "NABL 141 (Specific Criteria for PV Labs)",
+      "QMS-DOC-001 Quality Manual Rev.6",
+      "AUDIT-TEMPLATE-17025-v3",
+    ],
+  },
+  "iec 62915": {
+    answer: `## IEC 62915 - Type Test Sample Requirements for Design Changes
+
+IEC 62915 defines rules for **retesting requirements** when design modifications are made to already-certified PV modules.
+
+### Key Concepts
+- **Bill of Materials (BoM):** Comprehensive list of all module components
+- **Type Test Matrix:** Mapping of component changes to required retests
+- **Design Change Categories:** Minor, Major, Critical
+
+### Component Change → Retest Matrix
+| Component Changed | Required Retests |
+|-------------------|-----------------|
+| Cell supplier/type | Full IEC 61215 requalification |
+| Encapsulant material | TC200 + HF10 + DH1000 + UV |
+| Backsheet | DH1000 + UV + Insulation |
+| Junction box | Bypass diode + Insulation + Wet leakage |
+| Frame design | Mechanical load + Hail |
+| Glass (same spec, new supplier) | Hail + Mechanical load |
+| Interconnect ribbon | TC200 + HF10 |
+| Solder flux only | TC50 + HF10 (reduced) |
+
+### Decision Process
+1. Document complete BoM for certified design (baseline)
+2. Identify ALL component changes from baseline
+3. Map each change against IEC 62915 Table 1
+4. Determine combined test requirements (union of all changes)
+5. Execute minimum retest program
+6. Update BoM documentation and certificate
+
+### Important Notes
+- Multiple simultaneous changes require the **union** of all retests
+- Some CBs accept IEC 62915 for reduced retesting; verify with your CB
+- BoM documentation must be maintained as a controlled document
+- Cross-reference with IEC 61215 and IEC 61730 test reports`,
+    sources: [
+      "IEC TS 62915:2018 §5-7",
+      "IEC 62915 Table 1 (Retest Matrix)",
+      "CB Scheme Guidance OD-2019-001",
+      "QMS-FORM-062 BoM Change Control",
+    ],
+  },
+  uncertainty: {
+    answer: `## Measurement Uncertainty Budget Template (ISO 17025 / GUM)
+
+### I-V Measurement Uncertainty at STC
+
+#### Type B Uncertainty Components
+| Source | Value | Distribution | Divisor | u(xi) |
+|--------|-------|-------------|---------|-------|
+| Reference cell calibration | ±1.0% | Normal (k=2) | 2.0 | 0.500% |
+| Spectral mismatch correction | ±0.5% | Rectangular | √3 | 0.289% |
+| Spatial non-uniformity of irradiance | ±1.0% | Rectangular | √3 | 0.577% |
+| Temperature measurement | ±1.0°C → ±0.4% | Rectangular | √3 | 0.231% |
+| Temperature correction coefficient | ±5% relative | Rectangular | √3 | 0.115% |
+| Data acquisition system | ±0.1% | Rectangular | √3 | 0.058% |
+| Irradiance setting | ±0.5% | Rectangular | √3 | 0.289% |
+
+#### Type A Uncertainty
+- Repeatability (n=10 measurements): s = 0.25%, u_A = s/√n = **0.079%**
+
+#### Combined & Expanded
+- **Combined standard uncertainty:** u_c = √(Σu_i²) = **0.93%**
+- **Effective degrees of freedom** (Welch-Satterthwaite): ν_eff ≈ 48
+- **Coverage factor:** k = 2.01 (95.45% confidence)
+- **Expanded uncertainty:** U = k × u_c = **±1.87%**
+
+### Template Structure for Your Lab
+1. Define measurand clearly (Pmax, Isc, Voc, FF)
+2. Identify all input quantities
+3. Evaluate Type A (statistical) components
+4. Evaluate Type B (non-statistical) components
+5. Calculate combined uncertainty
+6. Apply Welch-Satterthwaite for effective DoF
+7. Select coverage factor from t-distribution
+8. Report expanded uncertainty with confidence level
+
+Use the **Uncertainty Calculator** module in SolarLabX for automated computation.`,
+    sources: [
+      "GUM (JCGM 100:2008) §4-8",
+      "ISO/IEC 17025:2017 §7.6",
+      "IEC 60904-1:2020 Annex A",
+      "EA-4/02 M:2022 (Expression of Uncertainty)",
+      "Lab MU Budget MU-IV-001 Rev.3",
+    ],
+  },
+  calibration: {
+    answer: `## Equipment Calibration Requirements (ISO 17025)
+
+### General Requirements (ISO/IEC 17025:2017 §6.4)
+- All equipment affecting test results must be calibrated
+- Calibration must be traceable to SI units (via NMI or accredited lab)
+- Calibration intervals based on stability, usage, and manufacturer guidance
+- Intermediate checks between calibrations
+
+### Solar PV Lab Equipment Calibration Schedule
+| Equipment | Calibration Interval | Traceable To | Intermediate Check |
+|-----------|---------------------|-------------|-------------------|
+| Reference Cell | 12 months | WRR (via PTB/NREL/CalLab) | Monthly (compare cells) |
+| Sun Simulator | 12 months (classification) | IEC 60904-9 | Weekly uniformity check |
+| I-V Curve Tracer | 12 months | NMI (voltage & current) | Monthly (ref module) |
+| Temp/RH Chamber | 12 months (mapping) | NMI (temp & humidity) | Daily monitoring |
+| Thermocouples | 12 months | NMI (ITS-90) | Quarterly (ice point) |
+| Spectroradiometer | 12 months | NMI (spectral irradiance) | Monthly (lamp check) |
+| Insulation Tester | 12 months | NMI (voltage & resistance) | Before use (internal cal) |
+| Mechanical Load System | 12 months | NMI (force/pressure) | Monthly (check cell) |
+| Data Logger | 24 months | NMI (voltage) | Quarterly (reference) |
+| Pyranometer | 24 months | WRR (via regional center) | Monthly (compare) |
+
+### Calibration Records Must Include
+- Equipment ID and description
+- Calibration date and due date
+- Calibration procedure reference
+- Environmental conditions during calibration
+- Results with measurement uncertainty
+- Pass/fail determination against acceptance criteria
+- Calibration certificate number
+- Traceability chain documentation
+
+### Non-Conforming Equipment Procedure
+1. Immediately take out of service and label
+2. Evaluate impact on previous test results (lookback)
+3. Notify affected clients if results were impacted
+4. Recalibrate or repair before returning to service
+5. Document in CAPA system`,
+    sources: [
+      "ISO/IEC 17025:2017 §6.4-6.5",
+      "NABL 141:2019 Annex (PV Lab Specific)",
+      "SOP-CAL-001 Calibration Management Rev.5",
+      "Equipment Registry EQ-REG-2026",
+    ],
+  },
+};
+
+function findDemoResponse(query: string): {
+  answer: string;
+  sources: string[];
+} {
+  const q = query.toLowerCase();
+
+  if (q.includes("61215") || (q.includes("test") && q.includes("sequence")))
+    return DEMO_RESPONSES["iec 61215"];
+  if (
+    q.includes("qms") ||
+    q.includes("audit") ||
+    q.includes("checklist") ||
+    q.includes("17025")
+  )
+    return DEMO_RESPONSES["qms audit"];
+  if (q.includes("62915") || q.includes("design change") || q.includes("bom"))
+    return DEMO_RESPONSES["iec 62915"];
+  if (
+    q.includes("uncertainty") ||
+    q.includes("budget") ||
+    q.includes("gum") ||
+    q.includes("measurement")
+  )
+    return DEMO_RESPONSES["uncertainty"];
+  if (
+    q.includes("calibration") ||
+    q.includes("equipment") ||
+    q.includes("traceability")
+  )
+    return DEMO_RESPONSES["calibration"];
+
+  // Generic fallback
+  return {
+    answer: `Thank you for your question about "${query}".
+
+Based on the SolarLabX knowledge base covering IEC/ISO standards for solar PV testing:
+
+This is currently running in **demo mode**. In production with Pinecone RAG enabled, this query would be:
+
+1. **Embedded** using OpenAI text-embedding-3-small
+2. **Matched** against our vector database containing:
+   - IEC 61215, 61730, 62915, 60904, 60891, 62788, 61853, 62804, 61701, 62716
+   - ISO/IEC 17025 requirements
+   - Laboratory SOPs and work instructions
+3. **Augmented** with retrieved context and sent to Claude for a grounded answer
+
+### Quick Actions You Can Try
+- "IEC 61215 test sequence" - Complete test requirements
+- "QMS audit checklist ISO 17025" - Audit preparation
+- "IEC 62915 design changes" - Retest requirements
+- "Uncertainty budget template" - MU calculation guide
+- "Equipment calibration requirements" - Calibration schedules
+
+Configure \`PINECONE_API_KEY\`, \`ANTHROPIC_API_KEY\`, and \`OPENAI_API_KEY\` to enable full RAG mode.`,
+    sources: ["SolarLabX Demo Mode", "Knowledge Base (local)"],
+  };
+}
+
+async function* streamDemo(
+  query: string
+): AsyncGenerator<{ type: "text" | "sources"; data: string }> {
+  const resp = findDemoResponse(query);
+
+  // Stream the answer character-by-character in small chunks for realistic effect
+  const chars = resp.answer;
+  let i = 0;
+  while (i < chars.length) {
+    const chunkSize = Math.min(
+      3 + Math.floor(Math.random() * 8),
+      chars.length - i
+    );
+    yield { type: "text", data: chars.slice(i, i + chunkSize) };
+    i += chunkSize;
+    // Small delay simulated via the stream itself
+    await new Promise((r) => setTimeout(r, 10 + Math.random() * 20));
+  }
+
+  // Send sources as a final event
+  yield { type: "sources", data: JSON.stringify(resp.sources) };
+}
+
+// ---- Main handler ----------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { message, history = [] } = body as {
+      message: string;
+      history: ChatMessage[];
+    };
+
+    if (!message?.trim()) {
+      return new Response(JSON.stringify({ error: "Message is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const anthropicKey =
+      process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
+    const pineconeKey = process.env.PINECONE_API_KEY;
+    const openaiKey = process.env.OPENAI_API_KEY;
+
+    // ---------- DEMO MODE (no API keys) ----------
+    if (!anthropicKey) {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          for await (const chunk of streamDemo(message)) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)
+            );
+          }
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
+
+    // ---------- RAG MODE (with Pinecone + OpenAI embeddings) ----------
+    let ragContext = "";
+    let ragSources: string[] = [];
+
+    if (pineconeKey && openaiKey) {
+      const embedding = await embedText(message);
+      if (embedding.length > 0) {
+        const results = await queryPinecone(embedding, 5);
+        if (results.length > 0) {
+          ragContext = results
+            .map(
+              (r, i) =>
+                `[Source ${i + 1}: ${r.source} (relevance: ${(r.score * 100).toFixed(1)}%)]\n${r.text}`
+            )
+            .join("\n\n---\n\n");
+          ragSources = Array.from(new Set(results.map((r) => r.source)));
+        }
+      }
+    }
+
+    // Build system prompt
+    const systemPrompt = `You are SolarLabX AI Assistant, an expert in solar PV testing laboratory operations, IEC/ISO standards, and quality management systems.
+
+Your knowledge covers:
+- IEC 61215 (Design Qualification), IEC 61730 (Safety), IEC 61853 (Energy Rating)
+- IEC 60904 (Measurement Procedures), IEC 60891 (I-V Translation)
+- IEC 62915 (Type Test Sample Requirements), IEC 62788 (Material Testing)
+- IEC 62804 (PID), IEC 61701 (Salt Mist), IEC 62716 (Ammonia)
+- ISO/IEC 17025 (Lab Competence), ISO 9001 (Quality Management)
+- GUM (Guide to Uncertainty in Measurement)
+- NABL, ILAC, BIS compliance requirements
+
+${ragContext ? `\n## Retrieved Context from Knowledge Base\nUse the following retrieved information to ground your answer. Cite the source references.\n\n${ragContext}\n` : ""}
+
+Guidelines:
+- Provide technically accurate, detailed answers with specific clause/section references
+- Use markdown formatting with tables where appropriate
+- When citing standards, include edition year and specific clause numbers
+- If the context doesn't fully answer the question, supplement with your knowledge but note this
+- For procedural questions, include step-by-step instructions with acceptance criteria
+- Always mention relevant SolarLabX modules that can help (e.g., Uncertainty Calculator, LIMS, etc.)`;
+
+    // Build messages array
+    const claudeMessages = [
+      ...history.slice(-10).map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+      { role: "user", content: message },
+    ];
+
+    // Stream response
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const text of streamClaude(systemPrompt, claudeMessages)) {
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "text", data: text })}\n\n`
+              )
+            );
+          }
+
+          // Send sources if we have RAG context
+          if (ragSources.length > 0) {
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "sources", data: JSON.stringify(ragSources) })}\n\n`
+              )
+            );
+          }
+
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        } catch (err) {
+          console.error("Stream error:", err);
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "error", data: "Failed to generate response. Please try again." })}\n\n`
+            )
+          );
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    console.error("Chat API error:", error);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/app/api/pinecone/ingest/route.ts
+++ b/app/api/pinecone/ingest/route.ts
@@ -1,0 +1,271 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// POST /api/pinecone/ingest
+// Ingest text documents into Pinecone for RAG retrieval.
+//
+// Body: { documents: [{ text, source, metadata? }] }
+//   or  { text, source } for a single document
+//
+// Chunks the text with overlap, embeds via OpenAI, and upserts to Pinecone.
+// Returns { success, chunksIngested, documentSource }
+// ---------------------------------------------------------------------------
+
+interface IngestDocument {
+  text: string;
+  source: string;
+  metadata?: Record<string, string>;
+}
+
+// ---- Text chunking --------------------------------------------------------
+
+function chunkText(
+  text: string,
+  chunkSize = 800,
+  overlap = 150
+): string[] {
+  const chunks: string[] = [];
+  // Split by paragraph first for natural boundaries
+  const paragraphs = text.split(/\n\s*\n/);
+  let currentChunk = "";
+
+  for (const para of paragraphs) {
+    const trimmed = para.trim();
+    if (!trimmed) continue;
+
+    if (currentChunk.length + trimmed.length + 1 > chunkSize && currentChunk.length > 0) {
+      chunks.push(currentChunk.trim());
+      // Overlap: keep the tail of the current chunk
+      const words = currentChunk.split(/\s+/);
+      const overlapWords = words.slice(-Math.ceil(overlap / 5));
+      currentChunk = overlapWords.join(" ") + "\n\n" + trimmed;
+    } else {
+      currentChunk += (currentChunk ? "\n\n" : "") + trimmed;
+    }
+  }
+
+  if (currentChunk.trim()) {
+    chunks.push(currentChunk.trim());
+  }
+
+  // If a single chunk is too large, split it further by sentences
+  const result: string[] = [];
+  for (const chunk of chunks) {
+    if (chunk.length <= chunkSize * 1.5) {
+      result.push(chunk);
+    } else {
+      const sentences = chunk.match(/[^.!?]+[.!?]+/g) || [chunk];
+      let sub = "";
+      for (const sentence of sentences) {
+        if (sub.length + sentence.length > chunkSize && sub.length > 0) {
+          result.push(sub.trim());
+          const words = sub.split(/\s+/);
+          const overlapWords = words.slice(-Math.ceil(overlap / 5));
+          sub = overlapWords.join(" ") + " " + sentence;
+        } else {
+          sub += sentence;
+        }
+      }
+      if (sub.trim()) result.push(sub.trim());
+    }
+  }
+
+  return result;
+}
+
+// ---- Embedding helper ------------------------------------------------------
+
+async function embedBatch(
+  texts: string[],
+  apiKey: string
+): Promise<number[][]> {
+  // OpenAI supports batch embedding
+  const res = await fetch("https://api.openai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "text-embedding-3-small",
+      input: texts,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`OpenAI embedding error: ${res.status} - ${err}`);
+  }
+
+  const data = await res.json();
+  const items = data.data as { embedding: number[]; index: number }[];
+  items.sort((a, b) => a.index - b.index);
+  return items.map((d) => d.embedding);
+}
+
+// ---- Pinecone upsert -------------------------------------------------------
+
+async function upsertPinecone(
+  vectors: { id: string; values: number[]; metadata: Record<string, string> }[],
+  apiKey: string,
+  indexHost: string
+): Promise<void> {
+  const host = indexHost.startsWith("http")
+    ? indexHost
+    : `https://${indexHost}`;
+
+  // Upsert in batches of 100
+  for (let i = 0; i < vectors.length; i += 100) {
+    const batch = vectors.slice(i, i + 100);
+    const res = await fetch(`${host}/vectors/upsert`, {
+      method: "POST",
+      headers: {
+        "Api-Key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ vectors: batch }),
+    });
+
+    if (!res.ok) {
+      const err = await res.text();
+      throw new Error(`Pinecone upsert error: ${res.status} - ${err}`);
+    }
+  }
+}
+
+// ---- Main handler ----------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  try {
+    const pineconeKey = process.env.PINECONE_API_KEY;
+    const pineconeIndex = process.env.PINECONE_INDEX;
+    const openaiKey = process.env.OPENAI_API_KEY;
+
+    if (!pineconeKey || !pineconeIndex) {
+      return NextResponse.json(
+        {
+          error: "Pinecone not configured",
+          message:
+            "Set PINECONE_API_KEY and PINECONE_INDEX environment variables to enable ingestion.",
+          demo: true,
+        },
+        { status: 200 }
+      );
+    }
+
+    if (!openaiKey) {
+      return NextResponse.json(
+        {
+          error: "OpenAI not configured",
+          message:
+            "Set OPENAI_API_KEY environment variable for text embeddings.",
+        },
+        { status: 200 }
+      );
+    }
+
+    const body = await request.json();
+
+    // Support single doc or array
+    let documents: IngestDocument[];
+    if (Array.isArray(body.documents)) {
+      documents = body.documents;
+    } else if (body.text && body.source) {
+      documents = [{ text: body.text, source: body.source, metadata: body.metadata }];
+    } else {
+      return NextResponse.json(
+        { error: "Provide { text, source } or { documents: [...] }" },
+        { status: 400 }
+      );
+    }
+
+    let totalChunks = 0;
+    const results: { source: string; chunks: number }[] = [];
+
+    for (const doc of documents) {
+      const chunks = chunkText(doc.text);
+      if (chunks.length === 0) continue;
+
+      // Embed in batches of 100
+      const allVectors: {
+        id: string;
+        values: number[];
+        metadata: Record<string, string>;
+      }[] = [];
+
+      for (let i = 0; i < chunks.length; i += 100) {
+        const batch = chunks.slice(i, i + 100);
+        const embeddings = await embedBatch(batch, openaiKey);
+
+        for (let j = 0; j < batch.length; j++) {
+          const chunkIndex = i + j;
+          allVectors.push({
+            id: `${doc.source.replace(/\s+/g, "-").toLowerCase()}-chunk-${chunkIndex}`,
+            values: embeddings[j],
+            metadata: {
+              text: batch[j],
+              source: doc.source,
+              chunkIndex: String(chunkIndex),
+              totalChunks: String(chunks.length),
+              ingestedAt: new Date().toISOString(),
+              ...(doc.metadata || {}),
+            },
+          });
+        }
+      }
+
+      await upsertPinecone(allVectors, pineconeKey, pineconeIndex);
+      totalChunks += allVectors.length;
+      results.push({ source: doc.source, chunks: allVectors.length });
+    }
+
+    return NextResponse.json({
+      success: true,
+      totalChunksIngested: totalChunks,
+      documents: results,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Ingest error:", error);
+    return NextResponse.json(
+      {
+        error: "Ingestion failed",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// GET /api/pinecone/ingest - Return ingest status / info
+export async function GET() {
+  const pineconeConfigured = !!(
+    process.env.PINECONE_API_KEY && process.env.PINECONE_INDEX
+  );
+  const openaiConfigured = !!process.env.OPENAI_API_KEY;
+
+  // List of supported standards for the knowledge base
+  const supportedStandards = [
+    { id: "iec-61215", name: "IEC 61215", title: "Design Qualification & Type Approval", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-61730", name: "IEC 61730", title: "PV Module Safety", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-62915", name: "IEC 62915", title: "Type Test Sample Requirements", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-60904", name: "IEC 60904", title: "PV Measurement Procedures", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-60891", name: "IEC 60891", title: "I-V Characteristic Translation", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-62788", name: "IEC 62788", title: "Material Testing Procedures", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-61853", name: "IEC 61853", title: "PV Module Energy Rating", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-62804", name: "IEC 62804", title: "PID Testing", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-61701", name: "IEC 61701", title: "Salt Mist Corrosion", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iec-62716", name: "IEC 62716", title: "Ammonia Corrosion", status: pineconeConfigured ? "ready" : "demo" },
+    { id: "iso-17025", name: "ISO/IEC 17025", title: "Lab Competence Requirements", status: pineconeConfigured ? "ready" : "demo" },
+  ];
+
+  return NextResponse.json({
+    pineconeConfigured,
+    openaiConfigured,
+    mode: pineconeConfigured ? "rag" : "demo",
+    standards: supportedStandards,
+    embeddingModel: "text-embedding-3-small",
+    chunkSize: 800,
+    chunkOverlap: 150,
+  });
+}

--- a/components/chatbot/KnowledgeBase.tsx
+++ b/components/chatbot/KnowledgeBase.tsx
@@ -1,0 +1,347 @@
+// @ts-nocheck
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Database,
+  Upload,
+  Search,
+  FileText,
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+  RefreshCw,
+  BookOpen,
+  Zap,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface StandardInfo {
+  id: string;
+  name: string;
+  title: string;
+  status: "ready" | "demo" | "indexing";
+}
+
+interface IngestStatus {
+  pineconeConfigured: boolean;
+  openaiConfigured: boolean;
+  mode: "rag" | "demo";
+  standards: StandardInfo[];
+  embeddingModel: string;
+  chunkSize: number;
+  chunkOverlap: number;
+}
+
+export default function KnowledgeBase() {
+  const [status, setStatus] = useState<IngestStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    fetchStatus();
+  }, []);
+
+  const fetchStatus = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/pinecone/ingest");
+      if (res.ok) {
+        setStatus(await res.json());
+      }
+    } catch {
+      // Use fallback demo status
+      setStatus({
+        pineconeConfigured: false,
+        openaiConfigured: false,
+        mode: "demo",
+        standards: [
+          { id: "iec-61215", name: "IEC 61215", title: "Design Qualification & Type Approval", status: "demo" },
+          { id: "iec-61730", name: "IEC 61730", title: "PV Module Safety", status: "demo" },
+          { id: "iec-62915", name: "IEC 62915", title: "Type Test Sample Requirements", status: "demo" },
+          { id: "iec-60904", name: "IEC 60904", title: "PV Measurement Procedures", status: "demo" },
+          { id: "iec-60891", name: "IEC 60891", title: "I-V Characteristic Translation", status: "demo" },
+          { id: "iec-62788", name: "IEC 62788", title: "Material Testing Procedures", status: "demo" },
+          { id: "iec-61853", name: "IEC 61853", title: "PV Module Energy Rating", status: "demo" },
+          { id: "iec-62804", name: "IEC 62804", title: "PID Testing", status: "demo" },
+          { id: "iec-61701", name: "IEC 61701", title: "Salt Mist Corrosion", status: "demo" },
+          { id: "iec-62716", name: "IEC 62716", title: "Ammonia Corrosion", status: "demo" },
+          { id: "iso-17025", name: "ISO/IEC 17025", title: "Lab Competence Requirements", status: "demo" },
+        ],
+        embeddingModel: "text-embedding-3-small",
+        chunkSize: 800,
+        chunkOverlap: 150,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    setUploadResult(null);
+
+    try {
+      const text = await file.text();
+      const source = file.name.replace(/\.(pdf|txt|md)$/i, "");
+
+      const res = await fetch("/api/pinecone/ingest", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text,
+          source,
+          metadata: {
+            fileName: file.name,
+            fileSize: String(file.size),
+            uploadedAt: new Date().toISOString(),
+          },
+        }),
+      });
+
+      const data = await res.json();
+
+      if (data.success) {
+        setUploadResult(
+          `Ingested "${source}" — ${data.totalChunksIngested} chunks created`
+        );
+        fetchStatus();
+      } else if (data.demo) {
+        setUploadResult(
+          "Demo mode: Configure Pinecone & OpenAI API keys to enable document ingestion."
+        );
+      } else {
+        setUploadResult(`Error: ${data.error || data.message}`);
+      }
+    } catch (err) {
+      setUploadResult("Upload failed. Check console for details.");
+      console.error("Upload error:", err);
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const filteredStandards = status?.standards?.filter(
+    (s) =>
+      !searchQuery ||
+      s.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      s.title.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Status Banner */}
+      <Card className="p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div
+              className={cn(
+                "h-10 w-10 rounded-lg flex items-center justify-center",
+                status?.mode === "rag"
+                  ? "bg-green-100 dark:bg-green-900/30"
+                  : "bg-amber-100 dark:bg-amber-900/30"
+              )}
+            >
+              {status?.mode === "rag" ? (
+                <Zap className="h-5 w-5 text-green-600 dark:text-green-400" />
+              ) : (
+                <Database className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+              )}
+            </div>
+            <div>
+              <h3 className="font-semibold text-sm">
+                {status?.mode === "rag"
+                  ? "RAG Mode Active"
+                  : "Demo Mode (Local Knowledge Base)"}
+              </h3>
+              <p className="text-xs text-muted-foreground">
+                {status?.mode === "rag"
+                  ? `Pinecone connected · Embedding: ${status.embeddingModel} · Chunk size: ${status.chunkSize}`
+                  : "Configure PINECONE_API_KEY, OPENAI_API_KEY, and PINECONE_INDEX to enable vector search"}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge
+              variant={status?.pineconeConfigured ? "default" : "secondary"}
+              className="text-xs"
+            >
+              Pinecone {status?.pineconeConfigured ? "Connected" : "N/A"}
+            </Badge>
+            <Badge
+              variant={status?.openaiConfigured ? "default" : "secondary"}
+              className="text-xs"
+            >
+              Embeddings {status?.openaiConfigured ? "Active" : "N/A"}
+            </Badge>
+            <Button variant="ghost" size="icon" onClick={fetchStatus}>
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      {/* Upload Section */}
+      <Card className="p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Upload className="h-4 w-4 text-muted-foreground" />
+            <h3 className="font-semibold text-sm">Upload Documents</h3>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            Supported: .txt, .md (PDF text extraction coming soon)
+          </span>
+        </div>
+        <div className="flex gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".txt,.md,.pdf"
+            className="hidden"
+            onChange={handleFileUpload}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+          >
+            {uploading ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Upload className="h-4 w-4 mr-2" />
+            )}
+            {uploading ? "Processing..." : "Choose File"}
+          </Button>
+        </div>
+        {uploadResult && (
+          <p
+            className={cn(
+              "text-xs mt-2",
+              uploadResult.startsWith("Error") || uploadResult.startsWith("Upload failed")
+                ? "text-red-600 dark:text-red-400"
+                : uploadResult.startsWith("Demo")
+                  ? "text-amber-600 dark:text-amber-400"
+                  : "text-green-600 dark:text-green-400"
+            )}
+          >
+            {uploadResult}
+          </p>
+        )}
+      </Card>
+
+      {/* Indexed Standards */}
+      <Card className="p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-4 w-4 text-muted-foreground" />
+            <h3 className="font-semibold text-sm">Indexed Standards</h3>
+            <Badge variant="outline" className="text-xs">
+              {status?.standards?.length ?? 0} standards
+            </Badge>
+          </div>
+          <div className="relative w-48">
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            <Input
+              placeholder="Search standards..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 pl-8 text-xs"
+            />
+          </div>
+        </div>
+        <ScrollArea className="h-[340px]">
+          <div className="space-y-2">
+            {filteredStandards?.map((standard) => (
+              <div
+                key={standard.id}
+                className="flex items-center justify-between p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="h-8 w-8 rounded-md bg-primary/10 flex items-center justify-center">
+                    <FileText className="h-4 w-4 text-primary" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">{standard.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {standard.title}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {standard.status === "ready" ? (
+                    <Badge
+                      variant="default"
+                      className="text-xs bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                    >
+                      <CheckCircle2 className="h-3 w-3 mr-1" />
+                      Indexed
+                    </Badge>
+                  ) : standard.status === "indexing" ? (
+                    <Badge variant="secondary" className="text-xs">
+                      <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                      Indexing
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="text-xs text-amber-600 border-amber-300 dark:text-amber-400"
+                    >
+                      <AlertCircle className="h-3 w-3 mr-1" />
+                      Demo
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </Card>
+
+      {/* Configuration Info */}
+      <Card className="p-4">
+        <h3 className="font-semibold text-sm mb-2">RAG Configuration</h3>
+        <div className="grid grid-cols-2 gap-3 text-xs">
+          <div className="space-y-1">
+            <p className="text-muted-foreground">Embedding Model</p>
+            <p className="font-mono">{status?.embeddingModel ?? "text-embedding-3-small"}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-muted-foreground">Chunk Size / Overlap</p>
+            <p className="font-mono">
+              {status?.chunkSize ?? 800} / {status?.chunkOverlap ?? 150} tokens
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-muted-foreground">Vector DB</p>
+            <p className="font-mono">Pinecone (serverless)</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-muted-foreground">LLM</p>
+            <p className="font-mono">Claude Sonnet 4</p>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/components/dashboard/chatbot/ChatbotClient.tsx
+++ b/components/dashboard/chatbot/ChatbotClient.tsx
@@ -17,14 +17,23 @@ import {
   MessageCircle,
   Sparkles,
   Clock,
+  Database,
+  BookOpen,
+  FileText,
+  StopCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import KnowledgeBase from "@/components/chatbot/KnowledgeBase";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
-  timestamp: Date;
+  timestamp: string; // ISO string for serialization
   sources?: string[];
 }
 
@@ -32,258 +41,290 @@ interface ChatSession {
   id: string;
   title: string;
   messages: Message[];
-  createdAt: Date;
+  createdAt: string;
 }
 
-const SUGGESTED_PROMPTS = [
-  "What tests are needed for IEC 61215?",
-  "Show me climate chamber availability",
-  "What is the uncertainty budget for IV measurements?",
-  "Explain the damp heat test procedure",
-  "What are the acceptance criteria for thermal cycling?",
-  "How to classify a sun simulator per IEC 60904-9?",
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const QUICK_ACTIONS = [
+  { label: "IEC 61215 test sequence", prompt: "What are the complete test requirements for IEC 61215 design qualification?" },
+  { label: "QMS audit checklist ISO 17025", prompt: "Provide a comprehensive QMS audit checklist for ISO/IEC 17025 accredited solar PV testing laboratory" },
+  { label: "IEC 62915 design changes", prompt: "Explain IEC 62915 retest requirements when design changes are made to certified PV modules" },
+  { label: "Uncertainty budget template", prompt: "Create a measurement uncertainty budget template for I-V measurements at STC per GUM methodology" },
+  { label: "Equipment calibration requirements", prompt: "What are the equipment calibration requirements and schedules for a solar PV testing lab per ISO 17025?" },
 ];
 
-const KNOWLEDGE_BASE: Record<string, { answer: string; sources: string[] }> = {
-  "iec 61215": {
-    answer: `**IEC 61215 - Design Qualification and Type Approval for Crystalline Silicon PV Modules**
+const STORAGE_KEY = "solarlabx-chat-sessions";
 
-IEC 61215 requires the following test sequence:
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-**Initial Tests:**
-- MQT 01: Visual Inspection
-- MQT 02: Maximum Power Determination (I-V curve at STC)
-- MQT 03: Insulation Test
-- MQT 06: Performance at STC
-
-**Environmental & Stress Tests:**
-- MQT 10: UV Preconditioning (15 kWh/m² UV dose)
-- MQT 11: Thermal Cycling TC200 (-40°C to +85°C, 200 cycles)
-- MQT 12: Humidity Freeze (10 cycles, -40°C to +85°C/85%RH)
-- MQT 13: Damp Heat DH1000 (85°C/85%RH for 1000 hours)
-- MQT 16: Mechanical Load (2400/5400 Pa, 3 cycles)
-- MQT 17: Hail Test (25mm ice balls at 23 m/s)
-- MQT 18: Bypass Diode Test
-- MQT 09: Hot-spot Endurance Test (5 hours)
-
-**Acceptance Criteria:**
-- Power degradation < 5% from initial
-- No major visual defects
-- Insulation resistance > 40 MΩ·m²
-- Wet leakage current within limits
-
-All tests must be performed on a minimum of 8 modules across 4 test sequences.`,
-    sources: ["IEC 61215-1:2021", "IEC 61215-2:2021", "SOP-LAB-001", "SOP-LAB-012"],
-  },
-  "climate chamber": {
-    answer: `**Climate Chamber Availability**
-
-Current chamber status in the lab:
-
-| Chamber | Type | Status | Current Test |
-|---------|------|--------|-------------|
-| TC-001 | Thermal Cycling | 🟢 Available | - |
-| TC-002 | Thermal Cycling | 🔴 In Use | TC200 (Module MOD-2026-0145) - 87% complete |
-| DH-001 | Damp Heat | 🔴 In Use | DH1000 (Module MOD-2026-0139) - 42% complete |
-| DH-002 | Damp Heat | 🟢 Available | - |
-| HF-001 | Humidity Freeze | 🟡 Maintenance | Scheduled calibration Mar 12 |
-| UV-001 | UV Chamber | 🟢 Available | - |
-
-**Upcoming Availability:**
-- TC-002: Available ~Mar 15 (TC200 completion)
-- DH-001: Available ~Apr 2 (DH1000 completion)
-- HF-001: Available Mar 13 (after calibration)
-
-Contact the Lab Manager to schedule chamber time.`,
-    sources: ["Equipment Registry", "Lab Schedule System", "Calibration Records"],
-  },
-  "uncertainty": {
-    answer: `**Measurement Uncertainty Budget for I-V Measurements**
-
-Per ISO/IEC 17025 and the GUM methodology, the uncertainty budget for I-V measurements at STC includes:
-
-**Type B Uncertainty Components:**
-| Source | Uncertainty | Distribution | Divisor | u(xi) |
-|--------|-----------|-------------|---------|-------|
-| Reference cell calibration | ±1.0% | Normal (k=2) | 2.0 | 0.50% |
-| Spectral mismatch | ±0.5% | Rectangular | √3 | 0.29% |
-| Spatial non-uniformity | ±1.0% | Rectangular | √3 | 0.58% |
-| Temperature measurement | ±1.0°C → ±0.4% | Rectangular | √3 | 0.23% |
-| Data acquisition | ±0.1% | Rectangular | √3 | 0.06% |
-
-**Type A Uncertainty:**
-- Repeatability (10 measurements): u_A = 0.15%
-
-**Combined Standard Uncertainty:**
-u_c = √(0.50² + 0.29² + 0.58² + 0.23² + 0.06² + 0.15²) = **0.86%**
-
-**Expanded Uncertainty (k=2, 95% confidence):**
-U = 2 × 0.86% = **±1.72%**
-
-This meets the ISO 17025 requirement for declared measurement uncertainty.`,
-    sources: ["ISO/IEC 17025:2017", "GUM (JCGM 100:2008)", "Lab MU Budget Rev 3", "IEC 60904-1"],
-  },
-  "damp heat": {
-    answer: `**Damp Heat Test Procedure (IEC 61215, MQT 13)**
-
-**Purpose:** Evaluate module resistance to long-term humidity penetration.
-
-**Test Conditions:**
-- Temperature: 85 ± 2°C
-- Relative Humidity: 85 ± 5% RH
-- Duration: 1000 hours continuous
-
-**Procedure:**
-1. **Pre-test characterization:** I-V curve at STC, insulation resistance, visual inspection, EL imaging
-2. **Chamber setup:** Verify chamber calibration, set 85°C/85%RH
-3. **Module loading:** Place modules in chamber without stacking, ensure air circulation
-4. **Monitoring:** Log temperature and RH every 15 minutes
-5. **Duration:** Maintain for 1000 hours without interruption
-6. **Recovery:** After test, condition at 23 ± 5°C for 2-24 hours
-7. **Post-test:** Repeat all initial characterization tests
-
-**Acceptance Criteria:**
-- Maximum power degradation: < 5% from initial value
-- No major visual defects (IEC 61215-1, Table 1)
-- Insulation resistance: > 40 MΩ·m²
-- No open circuits or ground faults
-
-**Safety Note:** Monitor for potential condensation during ramp-up/ramp-down phases.`,
-    sources: ["IEC 61215-2:2021 MQT 13", "SOP-LAB-014", "IEC 60068-2-78"],
-  },
-  "thermal cycling": {
-    answer: `**Thermal Cycling Test Procedure (IEC 61215, MQT 11)**
-
-**Test Parameters:**
-- Temperature range: -40°C to +85°C
-- Number of cycles: 200 (TC200) or 50 (TC50)
-- Ramp rate: ≤ 100°C/hour (max)
-- Dwell time at extremes: ≥ 10 minutes
-- Current injection: Apply at maximum power current during cycling
-
-**Test Sequence:**
-1. Pre-test: I-V, insulation, visual, EL
-2. Program chamber: -40°C → +85°C → -40°C per cycle
-3. Apply current injection per MQT 11.3 from cycle 1
-4. Monitor module temperature via thermocouples
-5. Complete 200 cycles (approximately 8-10 days)
-6. Post-test: Recovery 24h, then I-V, insulation, visual, EL
-
-**Acceptance:** < 5% power degradation, no major visual defects.`,
-    sources: ["IEC 61215-2:2021 MQT 11", "SOP-LAB-012", "IEC 60068-2-14"],
-  },
-  "sun simulator": {
-    answer: `**Sun Simulator Classification per IEC 60904-9 Ed.3**
-
-A solar simulator is classified based on three parameters:
-
-**1. Spectral Match (A+/A/B/C):**
-Ratio of actual spectral irradiance to reference AM1.5G spectrum in 6 wavelength intervals (300-1200 nm).
-- A+: 0.875 - 1.125 (±12.5%)
-- A: 0.75 - 1.25 (±25%)
-- B: 0.60 - 1.40 (±40%)
-- C: 0.40 - 2.00 (±100%)
-
-**2. Spatial Non-Uniformity:**
-Variation of irradiance across the test plane.
-- A+: ≤ 1%
-- A: ≤ 2%
-- B: ≤ 5%
-- C: ≤ 10%
-
-**3. Temporal Instability:**
-Short-term (STI) and long-term (LTI) irradiance variation.
-- A+: STI ≤ 0.25%, LTI ≤ 0.5%
-- A: STI ≤ 0.5%, LTI ≤ 2%
-- B: STI ≤ 2%, LTI ≤ 5%
-- C: STI ≤ 5%, LTI ≤ 10%
-
-**Classification format:** e.g., A+AA means Spectral A+, Spatial A, Temporal A.
-
-Use the SolarLabX Sun Simulator Classifier module for automated classification.`,
-    sources: ["IEC 60904-9 Ed.3:2020", "SunSim Classifier Module", "Lab Equipment Registry"],
-  },
-};
-
-function findBestMatch(query: string): { answer: string; sources: string[] } | null {
-  const q = query.toLowerCase();
-  const entries = Object.entries(KNOWLEDGE_BASE);
-
-  for (const [key, value] of entries) {
-    if (q.includes(key)) return value;
-  }
-
-  if (q.includes("test") && (q.includes("61215") || q.includes("qualification"))) {
-    return KNOWLEDGE_BASE["iec 61215"];
-  }
-  if (q.includes("chamber") || q.includes("availability") || q.includes("schedule")) {
-    return KNOWLEDGE_BASE["climate chamber"];
-  }
-  if (q.includes("uncertainty") || q.includes("mu ") || q.includes("gum") || q.includes("budget")) {
-    return KNOWLEDGE_BASE["uncertainty"];
-  }
-  if (q.includes("damp") || q.includes("humidity") && q.includes("85")) {
-    return KNOWLEDGE_BASE["damp heat"];
-  }
-  if (q.includes("thermal") || q.includes("cycling") || q.includes("tc200")) {
-    return KNOWLEDGE_BASE["thermal cycling"];
-  }
-  if (q.includes("simulator") || q.includes("60904-9") || q.includes("classify")) {
-    return KNOWLEDGE_BASE["sun simulator"];
-  }
-
-  return null;
+function generateId() {
+  return Math.random().toString(36).substring(2, 11) + Date.now().toString(36);
 }
 
-function generateMockResponse(query: string): { content: string; sources: string[] } {
-  const match = findBestMatch(query);
-  if (match) return { content: match.answer, sources: match.sources };
+function loadSessions(): ChatSession[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as ChatSession[];
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    }
+  } catch {
+    // corrupt data, reset
+  }
+  return [createNewSession()];
+}
 
+function saveSessions(sessions: ChatSession[]) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+  } catch {
+    // storage full, ignore
+  }
+}
+
+function createNewSession(): ChatSession {
   return {
-    content: `Thank you for your question about "${query}".
-
-Based on the SolarLabX knowledge base, here's what I can share:
-
-This query relates to solar PV testing laboratory operations. While I don't have a specific pre-built answer for this exact question, in a production environment this would be answered using:
-
-1. **RAG Pipeline:** Your question would be embedded and matched against our vector database (Pinecone) containing:
-   - IEC/ISO standard summaries (61215, 61730, 60904, 17025)
-   - Laboratory SOPs and work instructions
-   - Equipment manuals and calibration records
-   - Test result databases
-
-2. **Suggested Actions:**
-   - Check the relevant SOP in the SOP Generator module
-   - Review test protocols in the LIMS module
-   - Consult the equipment registry for availability
-
-*Note: Connect your PINECONE_API_KEY and CLAUDE_API_KEY in environment variables to enable full RAG-powered responses.*
-
-Is there anything specific about IEC standards, test procedures, equipment, or lab operations I can help with?`,
-    sources: ["SolarLabX Knowledge Base", "RAG System (pending configuration)"],
+    id: generateId(),
+    title: "New Chat",
+    messages: [],
+    createdAt: new Date().toISOString(),
   };
 }
 
-function generateId() {
-  return Math.random().toString(36).substring(2, 11);
+// Simple markdown-ish rendering: bold, headers, tables, lists, code
+function renderMarkdown(text: string) {
+  // Split into lines for block-level processing
+  const lines = text.split("\n");
+  const elements: React.ReactNode[] = [];
+  let inTable = false;
+  let tableRows: string[][] = [];
+  let inCodeBlock = false;
+  let codeLines: string[] = [];
+  let listItems: string[] = [];
+  let listOrdered = false;
+
+  const flushTable = () => {
+    if (tableRows.length === 0) return;
+    elements.push(
+      <div key={`table-${elements.length}`} className="overflow-x-auto my-2">
+        <table className="text-xs border-collapse w-full">
+          <thead>
+            <tr>
+              {tableRows[0]?.map((cell, i) => (
+                <th
+                  key={i}
+                  className="border border-border/50 px-2 py-1 text-left font-semibold bg-muted/50"
+                >
+                  {cell.trim()}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {tableRows.slice(2).map((row, ri) => (
+              <tr key={ri}>
+                {row.map((cell, ci) => (
+                  <td key={ci} className="border border-border/50 px-2 py-1">
+                    {cell.trim()}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+    tableRows = [];
+    inTable = false;
+  };
+
+  const flushList = () => {
+    if (listItems.length === 0) return;
+    const Tag = listOrdered ? "ol" : "ul";
+    elements.push(
+      <Tag
+        key={`list-${elements.length}`}
+        className={cn("my-1 pl-5 text-sm", listOrdered ? "list-decimal" : "list-disc")}
+      >
+        {listItems.map((item, i) => (
+          <li key={i} dangerouslySetInnerHTML={{ __html: inlineFormat(item) }} />
+        ))}
+      </Tag>
+    );
+    listItems = [];
+  };
+
+  const inlineFormat = (s: string) => {
+    return s
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/`(.+?)`/g, '<code class="bg-muted px-1 py-0.5 rounded text-xs font-mono">$1</code>');
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Code blocks
+    if (line.trim().startsWith("```")) {
+      if (inCodeBlock) {
+        elements.push(
+          <pre
+            key={`code-${elements.length}`}
+            className="bg-muted rounded p-2 my-2 text-xs font-mono overflow-x-auto"
+          >
+            {codeLines.join("\n")}
+          </pre>
+        );
+        codeLines = [];
+        inCodeBlock = false;
+      } else {
+        flushTable();
+        flushList();
+        inCodeBlock = true;
+      }
+      continue;
+    }
+    if (inCodeBlock) {
+      codeLines.push(line);
+      continue;
+    }
+
+    // Table rows
+    if (line.trim().startsWith("|") && line.trim().endsWith("|")) {
+      flushList();
+      inTable = true;
+      const cells = line
+        .split("|")
+        .slice(1, -1);
+      tableRows.push(cells);
+      continue;
+    } else if (inTable) {
+      flushTable();
+    }
+
+    // Headings
+    const h3Match = line.match(/^### (.+)/);
+    const h2Match = line.match(/^## (.+)/);
+    if (h2Match) {
+      flushList();
+      elements.push(
+        <h2
+          key={`h2-${elements.length}`}
+          className="text-sm font-bold mt-3 mb-1"
+          dangerouslySetInnerHTML={{ __html: inlineFormat(h2Match[1]) }}
+        />
+      );
+      continue;
+    }
+    if (h3Match) {
+      flushList();
+      elements.push(
+        <h3
+          key={`h3-${elements.length}`}
+          className="text-sm font-semibold mt-2 mb-1"
+          dangerouslySetInnerHTML={{ __html: inlineFormat(h3Match[1]) }}
+        />
+      );
+      continue;
+    }
+
+    // Unordered list
+    const ulMatch = line.match(/^[-*] (.+)/);
+    const checkMatch = line.match(/^- \[[ x]\] (.+)/);
+    if (checkMatch) {
+      const checked = line.includes("[x]");
+      flushList(); // flush previous non-checkbox list
+      elements.push(
+        <div key={`check-${elements.length}`} className="flex items-start gap-2 text-sm my-0.5">
+          <span className="mt-0.5">{checked ? "✅" : "⬜"}</span>
+          <span dangerouslySetInnerHTML={{ __html: inlineFormat(checkMatch[1]) }} />
+        </div>
+      );
+      continue;
+    }
+    if (ulMatch) {
+      if (listOrdered && listItems.length > 0) flushList();
+      listOrdered = false;
+      listItems.push(ulMatch[1]);
+      continue;
+    }
+
+    // Ordered list
+    const olMatch = line.match(/^\d+\.\s+(.+)/);
+    if (olMatch) {
+      if (!listOrdered && listItems.length > 0) flushList();
+      listOrdered = true;
+      listItems.push(olMatch[1]);
+      continue;
+    }
+
+    // Flush any pending list
+    flushList();
+
+    // Empty line
+    if (!line.trim()) {
+      continue;
+    }
+
+    // Normal paragraph
+    elements.push(
+      <p
+        key={`p-${elements.length}`}
+        className="text-sm leading-relaxed my-1"
+        dangerouslySetInnerHTML={{ __html: inlineFormat(line) }}
+      />
+    );
+  }
+
+  // Flush remaining
+  flushTable();
+  flushList();
+  if (inCodeBlock && codeLines.length > 0) {
+    elements.push(
+      <pre key={`code-${elements.length}`} className="bg-muted rounded p-2 my-2 text-xs font-mono overflow-x-auto">
+        {codeLines.join("\n")}
+      </pre>
+    );
+  }
+
+  return <>{elements}</>;
 }
 
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function ChatbotClient() {
-  const [sessions, setSessions] = useState<ChatSession[]>(() => [
-    {
-      id: "default",
-      title: "New Chat",
-      messages: [],
-      createdAt: new Date(),
-    },
-  ]);
-  const [activeSessionId, setActiveSessionId] = useState("default");
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState("");
   const [input, setInput] = useState("");
-  const [isTyping, setIsTyping] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingContent, setStreamingContent] = useState("");
+  const [activeTab, setActiveTab] = useState<"chat" | "knowledge">("chat");
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
-  const activeSession = sessions.find((s) => s.id === activeSessionId) || sessions[0];
+  // Load sessions from localStorage on mount
+  useEffect(() => {
+    const loaded = loadSessions();
+    setSessions(loaded);
+    setActiveSessionId(loaded[0]?.id || "");
+  }, []);
+
+  // Persist sessions to localStorage
+  useEffect(() => {
+    if (sessions.length > 0) saveSessions(sessions);
+  }, [sessions]);
+
+  const activeSession =
+    sessions.find((s) => s.id === activeSessionId) || sessions[0];
 
   const scrollToBottom = useCallback(() => {
     if (scrollRef.current) {
@@ -293,83 +334,201 @@ export default function ChatbotClient() {
 
   useEffect(() => {
     scrollToBottom();
-  }, [activeSession?.messages.length, scrollToBottom]);
+  }, [activeSession?.messages.length, streamingContent, scrollToBottom]);
+
+  // ---- Send message with streaming ----------------------------------------
 
   const handleSend = async () => {
-    if (!input.trim() || isTyping) return;
+    if (!input.trim() || isStreaming) return;
 
     const userMessage: Message = {
       id: generateId(),
       role: "user",
       content: input.trim(),
-      timestamp: new Date(),
+      timestamp: new Date().toISOString(),
     };
 
+    // Add user message and update session title
     setSessions((prev) =>
       prev.map((s) => {
         if (s.id !== activeSessionId) return s;
         const updated = { ...s, messages: [...s.messages, userMessage] };
         if (s.messages.length === 0) {
-          updated.title = input.trim().substring(0, 50) + (input.trim().length > 50 ? "..." : "");
+          updated.title =
+            input.trim().substring(0, 50) +
+            (input.trim().length > 50 ? "..." : "");
         }
         return updated;
       })
     );
 
+    const query = input.trim();
     setInput("");
-    setIsTyping(true);
+    setIsStreaming(true);
+    setStreamingContent("");
 
-    await new Promise((resolve) => setTimeout(resolve, 800 + Math.random() * 1200));
+    const controller = new AbortController();
+    abortRef.current = controller;
 
-    const response = generateMockResponse(userMessage.content);
-    const assistantMessage: Message = {
-      id: generateId(),
-      role: "assistant",
-      content: response.content,
-      timestamp: new Date(),
-      sources: response.sources,
-    };
+    try {
+      // Build history from current session
+      const history = (activeSession?.messages ?? []).map((m) => ({
+        role: m.role,
+        content: m.content,
+      }));
 
-    setSessions((prev) =>
-      prev.map((s) =>
-        s.id === activeSessionId ? { ...s, messages: [...s.messages, assistantMessage] } : s
-      )
-    );
-    setIsTyping(false);
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: query, history }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new Error(`API error: ${res.status}`);
+      }
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("No response body");
+
+      const decoder = new TextDecoder();
+      let fullContent = "";
+      let sources: string[] = [];
+      let buf = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buf += decoder.decode(value, { stream: true });
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const payload = line.slice(6).trim();
+          if (payload === "[DONE]") break;
+
+          try {
+            const evt = JSON.parse(payload);
+            if (evt.type === "text") {
+              fullContent += evt.data;
+              setStreamingContent(fullContent);
+            } else if (evt.type === "sources") {
+              try {
+                sources = JSON.parse(evt.data);
+              } catch {
+                sources = [evt.data];
+              }
+            } else if (evt.type === "error") {
+              fullContent += `\n\n⚠️ ${evt.data}`;
+              setStreamingContent(fullContent);
+            }
+          } catch {
+            // ignore non-JSON
+          }
+        }
+      }
+
+      // Add complete assistant message
+      const assistantMessage: Message = {
+        id: generateId(),
+        role: "assistant",
+        content: fullContent || "I couldn't generate a response. Please try again.",
+        timestamp: new Date().toISOString(),
+        sources: sources.length > 0 ? sources : undefined,
+      };
+
+      setSessions((prev) =>
+        prev.map((s) =>
+          s.id === activeSessionId
+            ? { ...s, messages: [...s.messages, assistantMessage] }
+            : s
+        )
+      );
+    } catch (err) {
+      if ((err as Error).name === "AbortError") {
+        // User cancelled
+        if (streamingContent) {
+          const partialMessage: Message = {
+            id: generateId(),
+            role: "assistant",
+            content: streamingContent + "\n\n*[Response stopped by user]*",
+            timestamp: new Date().toISOString(),
+          };
+          setSessions((prev) =>
+            prev.map((s) =>
+              s.id === activeSessionId
+                ? { ...s, messages: [...s.messages, partialMessage] }
+                : s
+            )
+          );
+        }
+      } else {
+        console.error("Chat error:", err);
+        const errorMessage: Message = {
+          id: generateId(),
+          role: "assistant",
+          content:
+            "Sorry, I encountered an error processing your request. Please try again.",
+          timestamp: new Date().toISOString(),
+        };
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === activeSessionId
+              ? { ...s, messages: [...s.messages, errorMessage] }
+              : s
+          )
+        );
+      }
+    } finally {
+      setIsStreaming(false);
+      setStreamingContent("");
+      abortRef.current = null;
+    }
   };
 
+  const handleStop = () => {
+    abortRef.current?.abort();
+  };
+
+  // ---- Session management --------------------------------------------------
+
   const handleNewSession = () => {
-    const newSession: ChatSession = {
-      id: generateId(),
-      title: "New Chat",
-      messages: [],
-      createdAt: new Date(),
-    };
-    setSessions((prev) => [newSession, ...prev]);
-    setActiveSessionId(newSession.id);
+    const s = createNewSession();
+    setSessions((prev) => [s, ...prev]);
+    setActiveSessionId(s.id);
+    setActiveTab("chat");
   };
 
   const handleDeleteSession = (sessionId: string) => {
     if (sessions.length <= 1) return;
-    setSessions((prev) => prev.filter((s) => s.id !== sessionId));
-    if (activeSessionId === sessionId) {
-      const remaining = sessions.filter((s) => s.id !== sessionId);
-      setActiveSessionId(remaining[0]?.id || "");
-    }
+    setSessions((prev) => {
+      const updated = prev.filter((s) => s.id !== sessionId);
+      if (activeSessionId === sessionId) {
+        setActiveSessionId(updated[0]?.id || "");
+      }
+      return updated;
+    });
   };
 
-  const handleExportPDF = () => {
+  // ---- Export as PDF (text file with .txt extension for simplicity) ---------
+
+  const handleExport = () => {
+    if (!activeSession) return;
     const content = [
+      "=" .repeat(60),
       "SolarLabX AI Chat Export",
       `Session: ${activeSession.title}`,
-      `Date: ${new Date().toLocaleDateString()}`,
+      `Exported: ${new Date().toLocaleString()}`,
+      `Messages: ${activeSession.messages.length}`,
       "=".repeat(60),
       "",
       ...activeSession.messages.map(
         (m) =>
-          `[${m.role === "user" ? "You" : "SolarLabX AI"}] (${m.timestamp.toLocaleTimeString()})\n${m.content}\n${
-            m.sources ? `Sources: ${m.sources.join(", ")}` : ""
-          }\n`
+          `[${m.role === "user" ? "You" : "SolarLabX AI"}] (${new Date(m.timestamp).toLocaleTimeString()})\n${m.content}\n${
+            m.sources ? `\nSources: ${m.sources.join(", ")}` : ""
+          }\n${"─".repeat(40)}\n`
       ),
     ].join("\n");
 
@@ -377,15 +536,17 @@ export default function ChatbotClient() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `solarlabx-chat-${activeSession.id}.txt`;
+    a.download = `solarlabx-chat-${activeSession.title.replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.txt`;
     a.click();
     URL.revokeObjectURL(url);
   };
 
-  const handleSuggestedPrompt = (prompt: string) => {
+  const handleQuickAction = (prompt: string) => {
     setInput(prompt);
     inputRef.current?.focus();
   };
+
+  // ---- Render ---------------------------------------------------------------
 
   return (
     <div className="flex h-[calc(100vh-7rem)] gap-4">
@@ -408,7 +569,10 @@ export default function ChatbotClient() {
                     ? "bg-primary text-primary-foreground"
                     : "hover:bg-accent text-muted-foreground"
                 )}
-                onClick={() => setActiveSessionId(session.id)}
+                onClick={() => {
+                  setActiveSessionId(session.id);
+                  setActiveTab("chat");
+                }}
               >
                 <MessageCircle className="h-3.5 w-3.5 shrink-0" />
                 <span className="truncate flex-1">{session.title}</span>
@@ -427,163 +591,253 @@ export default function ChatbotClient() {
             ))}
           </div>
         </ScrollArea>
-        <div className="p-3 border-t">
-          <Button variant="outline" size="sm" className="w-full" onClick={handleExportPDF}>
+        <div className="p-3 border-t space-y-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={handleExport}
+            disabled={!activeSession || activeSession.messages.length === 0}
+          >
             <Download className="h-4 w-4 mr-2" />
             Export Chat
           </Button>
         </div>
       </div>
 
-      {/* Chat Area */}
+      {/* Main Area */}
       <div className="flex-1 flex flex-col border rounded-lg bg-card overflow-hidden">
-        {/* Chat Header */}
-        <div className="p-4 border-b flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
-              <Bot className="h-4 w-4 text-primary" />
+        {/* Header with tabs */}
+        <div className="border-b">
+          <div className="p-4 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
+                <Bot className="h-4 w-4 text-primary" />
+              </div>
+              <div>
+                <h2 className="font-semibold text-sm">SolarLabX AI Assistant</h2>
+                <p className="text-xs text-muted-foreground">
+                  RAG-powered knowledge base for solar PV testing
+                </p>
+              </div>
             </div>
-            <div>
-              <h2 className="font-semibold text-sm">SolarLabX AI Assistant</h2>
-              <p className="text-xs text-muted-foreground">
-                RAG-powered knowledge base for solar PV testing
-              </p>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="text-xs">
+                <Sparkles className="h-3 w-3 mr-1" />
+                Pinecone RAG
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                Claude API
+              </Badge>
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Badge variant="outline" className="text-xs">
-              <Sparkles className="h-3 w-3 mr-1" />
-              Pinecone RAG
-            </Badge>
-            <Badge variant="outline" className="text-xs">
-              Claude API
-            </Badge>
+          {/* Tab bar */}
+          <div className="flex gap-0 px-4">
+            <button
+              onClick={() => setActiveTab("chat")}
+              className={cn(
+                "px-4 py-2 text-xs font-medium border-b-2 transition-colors",
+                activeTab === "chat"
+                  ? "border-primary text-primary"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <MessageCircle className="h-3.5 w-3.5 inline mr-1.5" />
+              Chat
+            </button>
+            <button
+              onClick={() => setActiveTab("knowledge")}
+              className={cn(
+                "px-4 py-2 text-xs font-medium border-b-2 transition-colors",
+                activeTab === "knowledge"
+                  ? "border-primary text-primary"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <Database className="h-3.5 w-3.5 inline mr-1.5" />
+              Knowledge Base
+            </button>
           </div>
         </div>
 
-        {/* Messages */}
-        <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
-          {activeSession.messages.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full text-center">
-              <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center mb-4">
-                <Bot className="h-8 w-8 text-primary" />
-              </div>
-              <h3 className="text-lg font-semibold mb-2">SolarLabX AI Assistant</h3>
-              <p className="text-muted-foreground text-sm max-w-md mb-6">
-                Ask me anything about test standards, equipment, procedures, sample status,
-                uncertainty calculations, and laboratory operations.
-              </p>
-              <div className="grid grid-cols-2 gap-2 max-w-lg">
-                {SUGGESTED_PROMPTS.map((prompt) => (
-                  <button
-                    key={prompt}
-                    onClick={() => handleSuggestedPrompt(prompt)}
-                    className="text-left text-xs p-3 rounded-lg border hover:bg-accent transition-colors"
-                  >
-                    {prompt}
-                  </button>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <>
-              {activeSession.messages.map((message) => (
-                <div
-                  key={message.id}
-                  className={cn(
-                    "flex gap-3",
-                    message.role === "user" ? "justify-end" : "justify-start"
-                  )}
-                >
-                  {message.role === "assistant" && (
-                    <div className="h-7 w-7 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-1">
-                      <Bot className="h-3.5 w-3.5 text-primary" />
-                    </div>
-                  )}
-                  <div
-                    className={cn(
-                      "max-w-[70%] rounded-lg px-4 py-3",
-                      message.role === "user"
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-muted"
-                    )}
-                  >
-                    <div className="text-sm whitespace-pre-wrap leading-relaxed">
-                      {message.content}
-                    </div>
-                    {message.sources && message.sources.length > 0 && (
-                      <div className="mt-2 pt-2 border-t border-border/50">
-                        <p className="text-xs font-medium mb-1 opacity-70">Sources:</p>
-                        <div className="flex flex-wrap gap-1">
-                          {message.sources.map((src) => (
-                            <Badge
-                              key={src}
-                              variant="secondary"
-                              className="text-[10px] px-1.5 py-0"
-                            >
-                              {src}
-                            </Badge>
-                          ))}
+        {/* Tab content */}
+        {activeTab === "knowledge" ? (
+          <div className="flex-1 overflow-y-auto p-4">
+            <KnowledgeBase />
+          </div>
+        ) : (
+          <>
+            {/* Messages */}
+            <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
+              {activeSession?.messages.length === 0 && !isStreaming ? (
+                <div className="flex flex-col items-center justify-center h-full text-center">
+                  <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center mb-4">
+                    <Bot className="h-8 w-8 text-primary" />
+                  </div>
+                  <h3 className="text-lg font-semibold mb-2">
+                    SolarLabX AI Assistant
+                  </h3>
+                  <p className="text-muted-foreground text-sm max-w-md mb-6">
+                    Ask me anything about IEC/ISO standards, test procedures,
+                    equipment calibration, uncertainty calculations, QMS, and
+                    laboratory operations.
+                  </p>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 max-w-2xl">
+                    {QUICK_ACTIONS.map((action) => (
+                      <button
+                        key={action.label}
+                        onClick={() => handleQuickAction(action.prompt)}
+                        className="text-left text-xs p-3 rounded-lg border hover:bg-accent transition-colors"
+                      >
+                        <div className="flex items-start gap-2">
+                          <BookOpen className="h-3.5 w-3.5 text-primary mt-0.5 shrink-0" />
+                          <span>{action.label}</span>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <>
+                  {activeSession?.messages.map((message) => (
+                    <div
+                      key={message.id}
+                      className={cn(
+                        "flex gap-3",
+                        message.role === "user"
+                          ? "justify-end"
+                          : "justify-start"
+                      )}
+                    >
+                      {message.role === "assistant" && (
+                        <div className="h-7 w-7 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-1">
+                          <Bot className="h-3.5 w-3.5 text-primary" />
+                        </div>
+                      )}
+                      <div
+                        className={cn(
+                          "max-w-[75%] rounded-lg px-4 py-3",
+                          message.role === "user"
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted"
+                        )}
+                      >
+                        {message.role === "assistant" ? (
+                          <div className="prose-sm">
+                            {renderMarkdown(message.content)}
+                          </div>
+                        ) : (
+                          <div className="text-sm whitespace-pre-wrap leading-relaxed">
+                            {message.content}
+                          </div>
+                        )}
+                        {message.sources && message.sources.length > 0 && (
+                          <div className="mt-2 pt-2 border-t border-border/50">
+                            <p className="text-xs font-medium mb-1 opacity-70 flex items-center gap-1">
+                              <FileText className="h-3 w-3" />
+                              Sources:
+                            </p>
+                            <div className="flex flex-wrap gap-1">
+                              {message.sources.map((src) => (
+                                <Badge
+                                  key={src}
+                                  variant="secondary"
+                                  className="text-[10px] px-1.5 py-0"
+                                >
+                                  {src}
+                                </Badge>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        <div className="flex items-center gap-1 mt-1 opacity-50">
+                          <Clock className="h-2.5 w-2.5" />
+                          <span className="text-[10px]">
+                            {new Date(message.timestamp).toLocaleTimeString()}
+                          </span>
                         </div>
                       </div>
-                    )}
-                    <div className="flex items-center gap-1 mt-1 opacity-50">
-                      <Clock className="h-2.5 w-2.5" />
-                      <span className="text-[10px]">
-                        {message.timestamp.toLocaleTimeString()}
-                      </span>
+                      {message.role === "user" && (
+                        <div className="h-7 w-7 rounded-full bg-primary flex items-center justify-center shrink-0 mt-1">
+                          <User className="h-3.5 w-3.5 text-primary-foreground" />
+                        </div>
+                      )}
                     </div>
-                  </div>
-                  {message.role === "user" && (
-                    <div className="h-7 w-7 rounded-full bg-primary flex items-center justify-center shrink-0 mt-1">
-                      <User className="h-3.5 w-3.5 text-primary-foreground" />
+                  ))}
+
+                  {/* Streaming indicator */}
+                  {isStreaming && (
+                    <div className="flex gap-3 justify-start">
+                      <div className="h-7 w-7 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-1">
+                        <Bot className="h-3.5 w-3.5 text-primary" />
+                      </div>
+                      <div className="max-w-[75%] bg-muted rounded-lg px-4 py-3">
+                        {streamingContent ? (
+                          <div className="prose-sm">
+                            {renderMarkdown(streamingContent)}
+                            <span className="inline-block w-2 h-4 bg-primary/60 animate-pulse ml-0.5" />
+                          </div>
+                        ) : (
+                          <div className="flex gap-1">
+                            <span
+                              className="w-2 h-2 rounded-full bg-muted-foreground/40 animate-bounce"
+                              style={{ animationDelay: "0ms" }}
+                            />
+                            <span
+                              className="w-2 h-2 rounded-full bg-muted-foreground/40 animate-bounce"
+                              style={{ animationDelay: "150ms" }}
+                            />
+                            <span
+                              className="w-2 h-2 rounded-full bg-muted-foreground/40 animate-bounce"
+                              style={{ animationDelay: "300ms" }}
+                            />
+                          </div>
+                        )}
+                      </div>
                     </div>
                   )}
-                </div>
-              ))}
-              {isTyping && (
-                <div className="flex gap-3">
-                  <div className="h-7 w-7 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                    <Bot className="h-3.5 w-3.5 text-primary" />
-                  </div>
-                  <div className="bg-muted rounded-lg px-4 py-3">
-                    <div className="flex gap-1">
-                      <span className="w-2 h-2 rounded-full bg-muted-foreground/40 animate-bounce" style={{ animationDelay: "0ms" }} />
-                      <span className="w-2 h-2 rounded-full bg-muted-foreground/40 animate-bounce" style={{ animationDelay: "150ms" }} />
-                      <span className="w-2 h-2 rounded-full bg-muted-foreground/40 animate-bounce" style={{ animationDelay: "300ms" }} />
-                    </div>
-                  </div>
-                </div>
+                </>
               )}
-            </>
-          )}
-        </div>
+            </div>
 
-        {/* Input */}
-        <div className="p-4 border-t">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              handleSend();
-            }}
-            className="flex gap-2"
-          >
-            <Input
-              ref={inputRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="Ask about test standards, equipment, procedures..."
-              className="flex-1"
-              disabled={isTyping}
-            />
-            <Button type="submit" disabled={!input.trim() || isTyping}>
-              <Send className="h-4 w-4" />
-            </Button>
-          </form>
-          <p className="text-[10px] text-muted-foreground mt-2 text-center">
-            Powered by Claude API + Pinecone RAG. Configure PINECONE_API_KEY &amp; PINECONE_INDEX for production use.
-          </p>
-        </div>
+            {/* Input */}
+            <div className="p-4 border-t">
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  handleSend();
+                }}
+                className="flex gap-2"
+              >
+                <Input
+                  ref={inputRef}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  placeholder="Ask about IEC standards, test procedures, equipment, QMS..."
+                  className="flex-1"
+                  disabled={isStreaming}
+                />
+                {isStreaming ? (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={handleStop}
+                  >
+                    <StopCircle className="h-4 w-4" />
+                  </Button>
+                ) : (
+                  <Button type="submit" disabled={!input.trim()}>
+                    <Send className="h-4 w-4" />
+                  </Button>
+                )}
+              </form>
+              <p className="text-[10px] text-muted-foreground mt-2 text-center">
+                Powered by Claude API + Pinecone RAG. Works in demo mode
+                without API keys.
+              </p>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Refactored the chatbot component to support Retrieval-Augmented Generation (RAG) with Pinecone vector database integration, Claude API streaming, and a new Knowledge Base management interface. The system gracefully falls back to demo mode when API keys are not configured.

## Key Changes

### ChatbotClient Component (`components/dashboard/chatbot/ChatbotClient.tsx`)
- **Refactored message types**: Changed `timestamp` and `createdAt` from `Date` objects to ISO strings for proper serialization
- **Replaced hardcoded knowledge base** with API-driven responses via `/api/chat` endpoint
- **Implemented streaming support**: Added `AbortController` for cancellable requests and real-time response streaming with `setStreamingContent`
- **Added session persistence**: Integrated localStorage for saving/loading chat sessions with `STORAGE_KEY`
- **Renamed UI elements**: Changed "SUGGESTED_PROMPTS" to "QUICK_ACTIONS" with more detailed, domain-specific prompts
- **Added markdown rendering**: Implemented `renderMarkdown()` helper to parse and render markdown with support for:
  - Headers (h2, h3), bold text, inline code
  - Tables with proper styling
  - Ordered/unordered lists and checkboxes
  - Code blocks
- **New tab interface**: Added "chat" and "knowledge" tabs for switching between chat and knowledge base management
- **Added new icons**: Imported `Database`, `BookOpen`, `FileText`, `StopCircle` from lucide-react

### Chat API Endpoint (`app/api/chat/route.ts`)
- **New streaming endpoint** that accepts `{ message, history }` and returns Server-Sent Events (SSE)
- **RAG pipeline**:
  - Embeds user query using OpenAI's `text-embedding-3-small`
  - Queries Pinecone for relevant document chunks (top-5 by default)
  - Constructs system prompt with retrieved context
  - Streams Claude Sonnet 4 response back to client
- **Graceful fallbacks**:
  - Falls back to Claude-only (no RAG) if Pinecone is not configured
  - Falls back to demo mode with rich mock responses if no API keys are set
- **Demo responses** for common queries (IEC 61215, QMS audits, IEC 62915, uncertainty budgets, calibration)
- **Streaming implementation**: Parses Claude's SSE format and yields text chunks in real-time

### Knowledge Base Component (`components/chatbot/KnowledgeBase.tsx`)
- **New UI for managing vector database**: Displays Pinecone connection status and embedding configuration
- **Document upload interface**: Allows users to upload `.txt`, `.pdf`, or `.md` files for ingestion
- **Standards registry**: Shows list of supported standards (IEC 61215, ISO 17025, etc.) with their indexing status
- **Status indicators**: Visual badges for Pinecone and OpenAI API configuration
- **Fallback demo mode**: Displays pre-configured standards when APIs are not available

### Pinecone Ingestion Endpoint (`app/api/pinecone/ingest/route.ts`)
- **Document chunking**: Splits text into 800-character chunks with 150-character overlap
- **Batch embedding**: Sends chunks to OpenAI in batches of 100 for efficiency
- **Vector upsert**: Stores embeddings in Pinecone with metadata (source, file name, upload timestamp)
- **Error handling**: Returns demo mode indicator when Pinecone/OpenAI are not configured
- **GET support**: Returns current ingestion status and configured standards

### Environment Configuration (`.env.example`)
- Added `ANTHROPIC_API_KEY` as alternative to `CLAUDE_API_KEY`
- Added `OPENAI_API_KEY` for text embeddings
- Added `PINECONE_API_KEY` and `PINECONE_INDEX` for vector database

## Notable Implementation Details

- **Serialization-safe types**: All timestamps use ISO strings to avoid Date serialization issues in localStorage and API responses
- **Streaming architecture**: Client-side streaming with `AbortController`

https://claude.ai/code/session_01Ncf4dQW8xR67QQ2agoJJrD