### PR TITLE
feat(qms): add Kaizen, Risk Register, and Suggestion Tracker tabs

### DIFF
--- a/app/(dashboard)/qms/page.tsx
+++ b/app/(dashboard)/qms/page.tsx
@@ -15,12 +15,15 @@ import {
   ChevronRight, ChevronDown, FileText, BookOpen, ClipboardList, Layers,
   CheckCircle2, AlertTriangle, Clock, Search, Plus, Download, Eye,
   BarChart3, Shield, Settings, Users, Microscope, FileCheck, Activity,
-  GitBranch, Briefcase
+  GitBranch, Briefcase, TrendingUp, MessageSquare
 } from 'lucide-react'
 import { CAPATrackingDashboard, DocumentRevisionHistory, ManagementReviewDashboard } from '@/components/qms/QMSEnhancements'
 import ExternalDocumentsTab from '@/components/qms/ExternalDocumentsTab'
 import InternalDocumentsTab from '@/components/qms/InternalDocumentsTab'
 import QCQATab from '@/components/qms/QCQATab'
+import KaizenTab from '@/components/qms/KaizenTab'
+import RiskRegisterTab from '@/components/qms/RiskRegisterTab'
+import SuggestionTrackerTab from '@/components/qms/SuggestionTrackerTab'
 
 // ─── ISO 17025 Document Hierarchy ─────────────────────────────────────────────
 
@@ -547,6 +550,15 @@ export default function QMSDashboard() {
           <TabsTrigger value="qcqa" className="text-xs">
             <Microscope className="h-3 w-3 mr-1" /> QC / QA
           </TabsTrigger>
+          <TabsTrigger value="kaizen" className="text-xs">
+            <TrendingUp className="h-3 w-3 mr-1" /> Kaizen
+          </TabsTrigger>
+          <TabsTrigger value="risk-register" className="text-xs">
+            <Shield className="h-3 w-3 mr-1" /> Risk Register
+          </TabsTrigger>
+          <TabsTrigger value="suggestions" className="text-xs">
+            <MessageSquare className="h-3 w-3 mr-1" /> Suggestions
+          </TabsTrigger>
         </TabsList>
 
         {/* ── DASHBOARD TAB ──────────────────────────────────────── */}
@@ -939,6 +951,21 @@ export default function QMSDashboard() {
         {/* ── QC / QA TAB ──────────────────────────────────────────── */}
         <TabsContent value="qcqa" className="space-y-4 mt-4">
           <QCQATab />
+        </TabsContent>
+
+        {/* ── KAIZEN TAB (ISO 17025 Clause 8.6) ────────────────────── */}
+        <TabsContent value="kaizen" className="space-y-4 mt-4">
+          <KaizenTab />
+        </TabsContent>
+
+        {/* ── RISK REGISTER TAB (ISO 17025 Clause 8.5) ─────────────── */}
+        <TabsContent value="risk-register" className="space-y-4 mt-4">
+          <RiskRegisterTab />
+        </TabsContent>
+
+        {/* ── SUGGESTION TRACKER TAB ───────────────────────────────── */}
+        <TabsContent value="suggestions" className="space-y-4 mt-4">
+          <SuggestionTrackerTab />
         </TabsContent>
       </Tabs>
     </div>

--- a/components/qms/KaizenTab.tsx
+++ b/components/qms/KaizenTab.tsx
@@ -1,0 +1,476 @@
+// @ts-nocheck
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  TrendingUp, CheckCircle2, Clock, XCircle, Plus, Download,
+  BarChart3, Lightbulb, Target, Users, ArrowUp, ArrowDown, Minus
+} from "lucide-react";
+import {
+  LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid,
+  Tooltip, Legend, ResponsiveContainer, Cell
+} from "recharts";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type InitiativeStatus = "Proposed" | "In Progress" | "Completed" | "Rejected";
+type KaizenCategory = "Process" | "Equipment" | "Safety" | "Quality" | "Cost";
+
+interface KaizenEvent {
+  id: string;
+  date: string;
+  description: string;
+  category: KaizenCategory;
+  impactScore: number;
+  responsible: string;
+  status: InitiativeStatus;
+  beforeMetric: string;
+  afterMetric: string;
+  saving?: string;
+}
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const KAIZEN_EVENTS: KaizenEvent[] = [
+  {
+    id: "KZN-001",
+    date: "2026-01-08",
+    description: "Standardize IV curve measurement procedure to reduce setup time",
+    category: "Process",
+    impactScore: 8,
+    responsible: "Rajan Kumar",
+    status: "Completed",
+    beforeMetric: "45 min/sample",
+    afterMetric: "28 min/sample",
+    saving: "38% time reduction",
+  },
+  {
+    id: "KZN-002",
+    date: "2026-01-15",
+    description: "Implement barcode scanning for sample chain of custody",
+    category: "Quality",
+    impactScore: 9,
+    responsible: "Priya Sharma",
+    status: "Completed",
+    beforeMetric: "3.2% entry errors",
+    afterMetric: "0.1% entry errors",
+    saving: "97% error reduction",
+  },
+  {
+    id: "KZN-003",
+    date: "2026-02-01",
+    description: "Redesign thermal chamber loading rack for better airflow",
+    category: "Equipment",
+    impactScore: 7,
+    responsible: "Arvind Nair",
+    status: "In Progress",
+    beforeMetric: "±8°C uniformity",
+    afterMetric: "±3°C (target)",
+    saving: "Improved test validity",
+  },
+  {
+    id: "KZN-004",
+    date: "2026-02-10",
+    description: "Automate calibration reminder notifications",
+    category: "Process",
+    impactScore: 6,
+    responsible: "Meena Pillai",
+    status: "Completed",
+    beforeMetric: "Manual tracking, 2 missed/qtr",
+    afterMetric: "0 missed calibrations",
+    saving: "100% on-time calibration",
+  },
+  {
+    id: "KZN-005",
+    date: "2026-02-18",
+    description: "Batch test reporting template for IEC 61215 series",
+    category: "Process",
+    impactScore: 8,
+    responsible: "Suresh Menon",
+    status: "In Progress",
+    beforeMetric: "4 hrs/report",
+    afterMetric: "1.5 hrs (target)",
+    saving: "62% time reduction",
+  },
+  {
+    id: "KZN-006",
+    date: "2026-02-25",
+    description: "Personal protective equipment upgrade for UV testing area",
+    category: "Safety",
+    impactScore: 9,
+    responsible: "Kavya Reddy",
+    status: "Completed",
+    beforeMetric: "Basic UV goggles",
+    afterMetric: "Full-face UV shields + gloves",
+    saving: "Enhanced operator safety",
+  },
+  {
+    id: "KZN-007",
+    date: "2026-03-05",
+    description: "Consolidate reagent purchasing for cost savings",
+    category: "Cost",
+    impactScore: 5,
+    responsible: "Rajan Kumar",
+    status: "Proposed",
+    beforeMetric: "₹1.2L/quarter reagents",
+    afterMetric: "₹0.8L (target)",
+    saving: "₹40K/quarter",
+  },
+  {
+    id: "KZN-008",
+    date: "2026-03-10",
+    description: "Cross-train technicians on sun simulator operation",
+    category: "Process",
+    impactScore: 7,
+    responsible: "Priya Sharma",
+    status: "Proposed",
+    beforeMetric: "2 qualified operators",
+    afterMetric: "5 qualified operators",
+    saving: "Reduced bottlenecks",
+  },
+  {
+    id: "KZN-009",
+    date: "2026-03-12",
+    description: "Replace aging reference cell with new calibrated unit",
+    category: "Equipment",
+    impactScore: 4,
+    responsible: "Arvind Nair",
+    status: "Rejected",
+    beforeMetric: "Drift ±0.8%",
+    afterMetric: "Not approved – budget constraints",
+    saving: "Deferred to Q3 2026",
+  },
+];
+
+const MONTHLY_TRENDS = [
+  { month: "Oct '25", proposed: 2, inProgress: 1, completed: 1, rejected: 0 },
+  { month: "Nov '25", proposed: 3, inProgress: 2, completed: 2, rejected: 1 },
+  { month: "Dec '25", proposed: 1, inProgress: 3, completed: 3, rejected: 0 },
+  { month: "Jan '26", proposed: 4, inProgress: 2, completed: 4, rejected: 1 },
+  { month: "Feb '26", proposed: 3, inProgress: 3, completed: 3, rejected: 0 },
+  { month: "Mar '26", proposed: 3, inProgress: 2, completed: 1, rejected: 1 },
+];
+
+const CATEGORY_COLORS: Record<KaizenCategory, string> = {
+  Process: "#3b82f6",
+  Equipment: "#8b5cf6",
+  Safety: "#ef4444",
+  Quality: "#10b981",
+  Cost: "#f59e0b",
+};
+
+const STATUS_CONFIG: Record<InitiativeStatus, { color: string; icon: any; badge: string }> = {
+  Proposed: { color: "bg-blue-50 text-blue-700 border-blue-200", icon: Lightbulb, badge: "outline" },
+  "In Progress": { color: "bg-amber-50 text-amber-700 border-amber-200", icon: Clock, badge: "outline" },
+  Completed: { color: "bg-green-50 text-green-700 border-green-200", icon: CheckCircle2, badge: "outline" },
+  Rejected: { color: "bg-red-50 text-red-700 border-red-200", icon: XCircle, badge: "outline" },
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function KaizenTab() {
+  const [search, setSearch] = useState("");
+  const [filterStatus, setFilterStatus] = useState<InitiativeStatus | "All">("All");
+  const [filterCategory, setFilterCategory] = useState<KaizenCategory | "All">("All");
+
+  const filtered = KAIZEN_EVENTS.filter((e) => {
+    const matchSearch =
+      e.description.toLowerCase().includes(search.toLowerCase()) ||
+      e.responsible.toLowerCase().includes(search.toLowerCase()) ||
+      e.id.toLowerCase().includes(search.toLowerCase());
+    const matchStatus = filterStatus === "All" || e.status === filterStatus;
+    const matchCat = filterCategory === "All" || e.category === filterCategory;
+    return matchSearch && matchStatus && matchCat;
+  });
+
+  const totals = {
+    total: KAIZEN_EVENTS.length,
+    completed: KAIZEN_EVENTS.filter((e) => e.status === "Completed").length,
+    inProgress: KAIZEN_EVENTS.filter((e) => e.status === "In Progress").length,
+    proposed: KAIZEN_EVENTS.filter((e) => e.status === "Proposed").length,
+    avgImpact: (
+      KAIZEN_EVENTS.reduce((s, e) => s + e.impactScore, 0) / KAIZEN_EVENTS.length
+    ).toFixed(1),
+  };
+
+  const categoryData = (["Process", "Equipment", "Safety", "Quality", "Cost"] as KaizenCategory[]).map(
+    (cat) => ({
+      name: cat,
+      count: KAIZEN_EVENTS.filter((e) => e.category === cat).length,
+      fill: CATEGORY_COLORS[cat],
+    })
+  );
+
+  const exportCSV = () => {
+    const rows = [
+      ["ID", "Date", "Description", "Category", "Impact Score", "Responsible", "Status", "Before", "After", "Saving"],
+      ...KAIZEN_EVENTS.map((e) => [
+        e.id, e.date, e.description, e.category, e.impactScore, e.responsible,
+        e.status, e.beforeMetric, e.afterMetric, e.saving ?? "",
+      ]),
+    ];
+    const csv = rows.map((r) => r.map((c) => `"${c}"`).join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a"); a.href = url; a.download = "kaizen-events.csv"; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Reference */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground bg-blue-50 border border-blue-200 rounded-lg px-3 py-2">
+        <TrendingUp className="h-4 w-4 text-blue-600 flex-shrink-0" />
+        <span>
+          <strong>ISO 17025:2017 Clause 8.6 – Improvement:</strong> The laboratory shall identify and select opportunities for improvement, implement actions and review the effectiveness.
+        </span>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+        <Card className="border-l-4 border-l-blue-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Total Initiatives</div>
+            <div className="text-2xl font-bold">{totals.total}</div>
+            <div className="text-xs text-blue-600">All time</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-green-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Completed</div>
+            <div className="text-2xl font-bold text-green-700">{totals.completed}</div>
+            <div className="text-xs text-muted-foreground">{Math.round((totals.completed / totals.total) * 100)}% success rate</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-amber-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">In Progress</div>
+            <div className="text-2xl font-bold text-amber-700">{totals.inProgress}</div>
+            <div className="text-xs text-muted-foreground">Active now</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-purple-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Proposed</div>
+            <div className="text-2xl font-bold text-purple-700">{totals.proposed}</div>
+            <div className="text-xs text-muted-foreground">Awaiting review</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-teal-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Avg Impact Score</div>
+            <div className="text-2xl font-bold text-teal-700">{totals.avgImpact}</div>
+            <div className="text-xs text-muted-foreground">out of 10</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Charts Row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <BarChart3 className="h-4 w-4 text-blue-600" /> Monthly Improvement Trends
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={MONTHLY_TRENDS} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                <XAxis dataKey="month" tick={{ fontSize: 10 }} />
+                <YAxis tick={{ fontSize: 10 }} />
+                <Tooltip />
+                <Legend wrapperStyle={{ fontSize: 11 }} />
+                <Bar dataKey="completed" name="Completed" fill="#10b981" stackId="a" radius={[0, 0, 0, 0]} />
+                <Bar dataKey="inProgress" name="In Progress" fill="#f59e0b" stackId="a" />
+                <Bar dataKey="proposed" name="Proposed" fill="#3b82f6" stackId="a" />
+                <Bar dataKey="rejected" name="Rejected" fill="#ef4444" stackId="a" radius={[2, 2, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Target className="h-4 w-4 text-purple-600" /> Improvements by Category
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={categoryData} layout="vertical" margin={{ top: 4, right: 20, left: 40, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                <XAxis type="number" tick={{ fontSize: 10 }} />
+                <YAxis dataKey="name" type="category" tick={{ fontSize: 11 }} />
+                <Tooltip />
+                <Bar dataKey="count" name="Count" radius={[0, 4, 4, 0]}>
+                  {categoryData.map((entry, i) => (
+                    <Cell key={i} fill={entry.fill} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters & Table */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center justify-between">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Lightbulb className="h-4 w-4 text-amber-500" /> Kaizen Events Log
+            </CardTitle>
+            <div className="flex flex-wrap gap-2 items-center">
+              <Input
+                placeholder="Search events…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-7 text-xs w-44"
+              />
+              <select
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value as any)}
+                className="h-7 text-xs border rounded px-2 bg-background"
+              >
+                {["All", "Proposed", "In Progress", "Completed", "Rejected"].map((s) => (
+                  <option key={s}>{s}</option>
+                ))}
+              </select>
+              <select
+                value={filterCategory}
+                onChange={(e) => setFilterCategory(e.target.value as any)}
+                className="h-7 text-xs border rounded px-2 bg-background"
+              >
+                {["All", "Process", "Equipment", "Safety", "Quality", "Cost"].map((c) => (
+                  <option key={c}>{c}</option>
+                ))}
+              </select>
+              <Button size="sm" variant="outline" className="h-7 text-xs" onClick={exportCSV}>
+                <Download className="h-3 w-3 mr-1" /> Export
+              </Button>
+              <Button size="sm" className="h-7 text-xs">
+                <Plus className="h-3 w-3 mr-1" /> Add Kaizen
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b bg-muted/40">
+                <th className="text-left py-2 px-3 font-medium">ID</th>
+                <th className="text-left py-2 px-3 font-medium">Date</th>
+                <th className="text-left py-2 px-3 font-medium">Description</th>
+                <th className="text-left py-2 px-3 font-medium">Category</th>
+                <th className="text-center py-2 px-3 font-medium">Impact</th>
+                <th className="text-left py-2 px-3 font-medium">Responsible</th>
+                <th className="text-left py-2 px-3 font-medium">Before</th>
+                <th className="text-left py-2 px-3 font-medium">After / Saving</th>
+                <th className="text-left py-2 px-3 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((ev, i) => {
+                const cfg = STATUS_CONFIG[ev.status];
+                const StatusIcon = cfg.icon;
+                return (
+                  <tr key={ev.id} className={`border-b hover:bg-muted/30 ${i % 2 === 0 ? "" : "bg-muted/10"}`}>
+                    <td className="py-2 px-3 font-mono text-blue-700">{ev.id}</td>
+                    <td className="py-2 px-3 text-muted-foreground">{ev.date}</td>
+                    <td className="py-2 px-3 max-w-[220px]">
+                      <p className="truncate" title={ev.description}>{ev.description}</p>
+                    </td>
+                    <td className="py-2 px-3">
+                      <span
+                        className="px-2 py-0.5 rounded-full text-white font-medium"
+                        style={{ backgroundColor: CATEGORY_COLORS[ev.category] }}
+                      >
+                        {ev.category}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 text-center">
+                      <span
+                        className={`font-bold ${ev.impactScore >= 8 ? "text-green-700" : ev.impactScore >= 6 ? "text-amber-700" : "text-gray-600"}`}
+                      >
+                        {ev.impactScore}/10
+                      </span>
+                    </td>
+                    <td className="py-2 px-3">{ev.responsible}</td>
+                    <td className="py-2 px-3 text-muted-foreground max-w-[100px]">
+                      <p className="truncate" title={ev.beforeMetric}>{ev.beforeMetric}</p>
+                    </td>
+                    <td className="py-2 px-3 max-w-[130px]">
+                      <p className="truncate text-green-700" title={ev.saving ?? ev.afterMetric}>
+                        {ev.saving ?? ev.afterMetric}
+                      </p>
+                    </td>
+                    <td className="py-2 px-3">
+                      <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-xs font-medium ${cfg.color}`}>
+                        <StatusIcon className="h-3 w-3" />
+                        {ev.status}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={9} className="py-8 text-center text-muted-foreground">
+                    No kaizen events match your filters.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      {/* Before/After Metrics Visualization */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <ArrowUp className="h-4 w-4 text-green-600" /> Before / After Metrics — Completed Improvements
+          </CardTitle>
+          <CardDescription className="text-xs">Visual snapshot of measurable outcomes from completed kaizen events</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {KAIZEN_EVENTS.filter((e) => e.status === "Completed").map((ev) => (
+              <div key={ev.id} className="border rounded-lg p-3 bg-green-50/50">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="font-mono text-xs text-green-700">{ev.id}</span>
+                  <span
+                    className="text-xs px-1.5 py-0.5 rounded-full text-white"
+                    style={{ backgroundColor: CATEGORY_COLORS[ev.category] }}
+                  >
+                    {ev.category}
+                  </span>
+                </div>
+                <p className="text-xs font-medium mb-2 leading-tight">{ev.description}</p>
+                <div className="flex items-center gap-2 text-xs">
+                  <div className="flex-1 bg-red-50 border border-red-200 rounded p-1.5">
+                    <div className="text-red-500 font-medium mb-0.5">Before</div>
+                    <div className="text-red-700">{ev.beforeMetric}</div>
+                  </div>
+                  <ArrowUp className="h-4 w-4 text-green-500 flex-shrink-0" />
+                  <div className="flex-1 bg-green-50 border border-green-200 rounded p-1.5">
+                    <div className="text-green-600 font-medium mb-0.5">After</div>
+                    <div className="text-green-700">{ev.saving ?? ev.afterMetric}</div>
+                  </div>
+                </div>
+                <div className="mt-2 text-xs text-muted-foreground flex items-center gap-1">
+                  <Users className="h-3 w-3" /> {ev.responsible}
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/qms/RiskRegisterTab.tsx
+++ b/components/qms/RiskRegisterTab.tsx
@@ -1,0 +1,526 @@
+// @ts-nocheck
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Shield, AlertTriangle, CheckCircle2, XCircle, Download, Plus,
+  TrendingDown, BarChart3, Eye
+} from "lucide-react";
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  ResponsiveContainer, ScatterChart, Scatter, ZAxis, Cell
+} from "recharts";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type RiskCategory = "Technical" | "Operational" | "Financial" | "Compliance" | "Safety";
+type RiskStatus = "Open" | "Mitigated" | "Closed";
+
+interface Risk {
+  id: string;
+  description: string;
+  category: RiskCategory;
+  likelihood: number; // 1-5
+  impact: number;     // 1-5
+  mitigation: string;
+  owner: string;
+  status: RiskStatus;
+  reviewDate: string;
+  trend: "up" | "stable" | "down";
+}
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const RISKS: Risk[] = [
+  {
+    id: "RSK-001",
+    description: "Reference standard cell out-of-calibration detected mid-campaign",
+    category: "Technical",
+    likelihood: 3,
+    impact: 5,
+    mitigation: "Monthly verification against NABL-traceable reference; keep backup calibrated cell",
+    owner: "Arvind Nair",
+    status: "Open",
+    reviewDate: "2026-04-01",
+    trend: "stable",
+  },
+  {
+    id: "RSK-002",
+    description: "Loss of accreditation due to surveillance audit non-conformity",
+    category: "Compliance",
+    likelihood: 2,
+    impact: 5,
+    mitigation: "Internal pre-audit checklist; quarterly management review; corrective action register",
+    owner: "Priya Sharma",
+    status: "Mitigated",
+    reviewDate: "2026-06-15",
+    trend: "down",
+  },
+  {
+    id: "RSK-003",
+    description: "UV lamp aging causing spectral mismatch beyond IEC 60904-9 Class A limit",
+    category: "Technical",
+    likelihood: 4,
+    impact: 4,
+    mitigation: "Biannual spectral irradiance measurement; lamp replacement schedule at 1500 hr",
+    owner: "Meena Pillai",
+    status: "Open",
+    reviewDate: "2026-05-01",
+    trend: "up",
+  },
+  {
+    id: "RSK-004",
+    description: "Key technician attrition reducing test throughput capacity",
+    category: "Operational",
+    likelihood: 3,
+    impact: 3,
+    mitigation: "Cross-training program; documented SOPs; competitive retention package",
+    owner: "Rajan Kumar",
+    status: "Open",
+    reviewDate: "2026-04-15",
+    trend: "stable",
+  },
+  {
+    id: "RSK-005",
+    description: "ERP system downtime disrupting LIMS data entry during peak testing season",
+    category: "Operational",
+    likelihood: 2,
+    impact: 3,
+    mitigation: "Offline paper backup forms; cloud sync; vendor SLA for 4-hour recovery",
+    owner: "Suresh Menon",
+    status: "Mitigated",
+    reviewDate: "2026-07-01",
+    trend: "down",
+  },
+  {
+    id: "RSK-006",
+    description: "Budget overrun due to unexpected equipment repair in Q2",
+    category: "Financial",
+    likelihood: 3,
+    impact: 3,
+    mitigation: "10% contingency budget; preventive maintenance schedule; annual equipment insurance",
+    owner: "Kavya Reddy",
+    status: "Open",
+    reviewDate: "2026-04-30",
+    trend: "stable",
+  },
+  {
+    id: "RSK-007",
+    description: "UV radiation exposure to operators during IEC 62716 damp heat testing",
+    category: "Safety",
+    likelihood: 2,
+    impact: 4,
+    mitigation: "UV-rated PPE mandatory; safety interlock on chamber doors; annual safety training",
+    owner: "Arvind Nair",
+    status: "Mitigated",
+    reviewDate: "2026-03-31",
+    trend: "down",
+  },
+  {
+    id: "RSK-008",
+    description: "Data integrity breach in digital test records",
+    category: "Compliance",
+    likelihood: 1,
+    impact: 5,
+    mitigation: "Role-based access control; audit logs; encrypted backups; pen-test annually",
+    owner: "Priya Sharma",
+    status: "Closed",
+    reviewDate: "2026-12-31",
+    trend: "down",
+  },
+  {
+    id: "RSK-009",
+    description: "Delayed vendor delivery of test samples impacting schedule",
+    category: "Operational",
+    likelihood: 4,
+    impact: 2,
+    mitigation: "Buffer stock agreement; alternate supplier pre-qualified; client communication SOP",
+    owner: "Rajan Kumar",
+    status: "Open",
+    reviewDate: "2026-05-15",
+    trend: "stable",
+  },
+  {
+    id: "RSK-010",
+    description: "Client confidentiality breach via unsecured report sharing",
+    category: "Compliance",
+    likelihood: 1,
+    impact: 4,
+    mitigation: "Password-protected PDFs; secure client portal; staff confidentiality training",
+    owner: "Suresh Menon",
+    status: "Closed",
+    reviewDate: "2026-12-31",
+    trend: "down",
+  },
+];
+
+const TREND_DATA = [
+  { month: "Oct '25", open: 9, mitigated: 3, closed: 1 },
+  { month: "Nov '25", open: 9, mitigated: 3, closed: 2 },
+  { month: "Dec '25", open: 8, mitigated: 4, closed: 2 },
+  { month: "Jan '26", open: 8, mitigated: 4, closed: 2 },
+  { month: "Feb '26", open: 7, mitigated: 4, closed: 2 },
+  { month: "Mar '26", open: 6, mitigated: 3, closed: 2 },
+];
+
+const CATEGORY_COLORS: Record<RiskCategory, string> = {
+  Technical: "#8b5cf6",
+  Operational: "#3b82f6",
+  Financial: "#f59e0b",
+  Compliance: "#ef4444",
+  Safety: "#ec4899",
+};
+
+const STATUS_COLORS: Record<RiskStatus, string> = {
+  Open: "bg-red-50 text-red-700 border-red-200",
+  Mitigated: "bg-amber-50 text-amber-700 border-amber-200",
+  Closed: "bg-green-50 text-green-700 border-green-200",
+};
+
+// ─── Risk Score Cell Color ────────────────────────────────────────────────────
+
+function riskColor(score: number): string {
+  if (score >= 15) return "bg-red-600 text-white";
+  if (score >= 10) return "bg-orange-500 text-white";
+  if (score >= 6) return "bg-amber-400 text-black";
+  if (score >= 3) return "bg-yellow-300 text-black";
+  return "bg-green-200 text-black";
+}
+
+function matrixColor(likelihood: number, impact: number): string {
+  const score = likelihood * impact;
+  if (score >= 15) return "#dc2626";
+  if (score >= 10) return "#f97316";
+  if (score >= 6) return "#eab308";
+  if (score >= 3) return "#a3e635";
+  return "#4ade80";
+}
+
+// ─── Risk Matrix ──────────────────────────────────────────────────────────────
+
+function RiskMatrix({ risks }: { risks: Risk[] }) {
+  const LIKELIHOODS = [5, 4, 3, 2, 1];
+  const IMPACTS = [1, 2, 3, 4, 5];
+  const LABELS = ["Rare", "Unlikely", "Possible", "Likely", "Almost Certain"];
+  const IMPACT_LABELS = ["Negligible", "Minor", "Moderate", "Major", "Catastrophic"];
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="text-xs text-muted-foreground mb-2 font-medium text-center">
+        Likelihood vs Impact Matrix (ISO 17025 Clause 8.5)
+      </div>
+      <div className="inline-block">
+        <div className="flex items-end mb-1">
+          <div className="w-28" />
+          {IMPACTS.map((imp) => (
+            <div key={imp} className="w-16 text-center text-xs font-medium text-muted-foreground truncate">
+              {IMPACT_LABELS[imp - 1]}
+            </div>
+          ))}
+        </div>
+        {LIKELIHOODS.map((lik) => (
+          <div key={lik} className="flex items-center mb-1">
+            <div className="w-28 text-xs text-muted-foreground text-right pr-2 truncate">
+              {LABELS[lik - 1]}
+            </div>
+            {IMPACTS.map((imp) => {
+              const score = lik * imp;
+              const cellRisks = risks.filter((r) => r.likelihood === lik && r.impact === imp);
+              return (
+                <div
+                  key={imp}
+                  className="w-16 h-12 border border-white/40 flex flex-col items-center justify-center rounded-sm mx-0.5 relative cursor-default"
+                  style={{ backgroundColor: matrixColor(lik, imp) }}
+                  title={`L${lik} × I${imp} = ${score}\n${cellRisks.map((r) => r.id).join(", ")}`}
+                >
+                  <span className="text-xs font-bold opacity-70">{score}</span>
+                  {cellRisks.length > 0 && (
+                    <div className="flex flex-wrap gap-0.5 justify-center mt-0.5">
+                      {cellRisks.map((r) => (
+                        <span key={r.id} className="text-[9px] bg-white/70 text-gray-800 rounded px-0.5 font-mono">
+                          {r.id.replace("RSK-", "")}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+        {/* Legend */}
+        <div className="flex gap-3 mt-3 text-xs flex-wrap">
+          {[
+            { label: "Critical (≥15)", color: "#dc2626" },
+            { label: "High (10-14)", color: "#f97316" },
+            { label: "Medium (6-9)", color: "#eab308" },
+            { label: "Low (3-5)", color: "#a3e635" },
+            { label: "Negligible (1-2)", color: "#4ade80" },
+          ].map((l) => (
+            <span key={l.label} className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: l.color }} />
+              {l.label}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function RiskRegisterTab() {
+  const [search, setSearch] = useState("");
+  const [filterStatus, setFilterStatus] = useState<RiskStatus | "All">("All");
+  const [filterCategory, setFilterCategory] = useState<RiskCategory | "All">("All");
+
+  const filtered = RISKS.filter((r) => {
+    const matchSearch =
+      r.description.toLowerCase().includes(search.toLowerCase()) ||
+      r.id.toLowerCase().includes(search.toLowerCase()) ||
+      r.owner.toLowerCase().includes(search.toLowerCase());
+    const matchStatus = filterStatus === "All" || r.status === filterStatus;
+    const matchCat = filterCategory === "All" || r.category === filterCategory;
+    return matchSearch && matchStatus && matchCat;
+  });
+
+  const openRisks = RISKS.filter((r) => r.status === "Open");
+  const top5 = [...RISKS]
+    .sort((a, b) => b.likelihood * b.impact - a.likelihood * a.impact)
+    .slice(0, 5);
+
+  const exportCSV = () => {
+    const rows = [
+      ["ID", "Description", "Category", "Likelihood", "Impact", "Risk Score", "Mitigation", "Owner", "Status", "Review Date"],
+      ...RISKS.map((r) => [
+        r.id, r.description, r.category, r.likelihood, r.impact,
+        r.likelihood * r.impact, r.mitigation, r.owner, r.status, r.reviewDate,
+      ]),
+    ];
+    const csv = rows.map((row) => row.map((c) => `"${c}"`).join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a"); a.href = url; a.download = "risk-register.csv"; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Reference */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+        <Shield className="h-4 w-4 text-red-600 flex-shrink-0" />
+        <span>
+          <strong>ISO 17025:2017 Clause 8.5 – Actions to address risks and opportunities:</strong> The laboratory shall plan and implement actions to address the risks and opportunities.
+        </span>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Card className="border-l-4 border-l-red-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Open Risks</div>
+            <div className="text-2xl font-bold text-red-700">{RISKS.filter((r) => r.status === "Open").length}</div>
+            <div className="text-xs text-muted-foreground">Require action</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-amber-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Mitigated</div>
+            <div className="text-2xl font-bold text-amber-700">{RISKS.filter((r) => r.status === "Mitigated").length}</div>
+            <div className="text-xs text-muted-foreground">Under control</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-green-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Closed</div>
+            <div className="text-2xl font-bold text-green-700">{RISKS.filter((r) => r.status === "Closed").length}</div>
+            <div className="text-xs text-muted-foreground">Resolved</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-orange-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">High/Critical</div>
+            <div className="text-2xl font-bold text-orange-700">
+              {RISKS.filter((r) => r.likelihood * r.impact >= 10).length}
+            </div>
+            <div className="text-xs text-muted-foreground">Score ≥10</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Matrix + Top 5 */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Eye className="h-4 w-4 text-red-600" /> 5×5 Risk Matrix
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RiskMatrix risks={RISKS} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-orange-500" /> Top 5 Risks by Score
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {top5.map((r, i) => {
+              const score = r.likelihood * r.impact;
+              return (
+                <div key={r.id} className="flex items-center gap-3">
+                  <span className="text-xs text-muted-foreground w-5 text-right">{i + 1}.</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xs font-medium truncate">{r.description}</div>
+                    <div className="text-[10px] text-muted-foreground">{r.id} · {r.category} · {r.owner}</div>
+                  </div>
+                  <span
+                    className={`text-xs font-bold px-2 py-1 rounded ${riskColor(score)}`}
+                  >
+                    {score}
+                  </span>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Risk Trend */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <TrendingDown className="h-4 w-4 text-green-600" /> Risk Status Trend
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={TREND_DATA} margin={{ top: 4, right: 20, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <XAxis dataKey="month" tick={{ fontSize: 10 }} />
+              <YAxis tick={{ fontSize: 10 }} />
+              <Tooltip />
+              <Legend wrapperStyle={{ fontSize: 11 }} />
+              <Line type="monotone" dataKey="open" name="Open" stroke="#ef4444" strokeWidth={2} dot={{ r: 3 }} />
+              <Line type="monotone" dataKey="mitigated" name="Mitigated" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} />
+              <Line type="monotone" dataKey="closed" name="Closed" stroke="#10b981" strokeWidth={2} dot={{ r: 3 }} />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* Risk Register Table */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center justify-between">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <BarChart3 className="h-4 w-4 text-red-600" /> Risk Register
+            </CardTitle>
+            <div className="flex flex-wrap gap-2 items-center">
+              <Input
+                placeholder="Search risks…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-7 text-xs w-44"
+              />
+              <select
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value as any)}
+                className="h-7 text-xs border rounded px-2 bg-background"
+              >
+                {["All", "Open", "Mitigated", "Closed"].map((s) => (
+                  <option key={s}>{s}</option>
+                ))}
+              </select>
+              <select
+                value={filterCategory}
+                onChange={(e) => setFilterCategory(e.target.value as any)}
+                className="h-7 text-xs border rounded px-2 bg-background"
+              >
+                {["All", "Technical", "Operational", "Financial", "Compliance", "Safety"].map((c) => (
+                  <option key={c}>{c}</option>
+                ))}
+              </select>
+              <Button size="sm" variant="outline" className="h-7 text-xs" onClick={exportCSV}>
+                <Download className="h-3 w-3 mr-1" /> Export CSV
+              </Button>
+              <Button size="sm" className="h-7 text-xs">
+                <Plus className="h-3 w-3 mr-1" /> Add Risk
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b bg-muted/40">
+                <th className="text-left py-2 px-3 font-medium">ID</th>
+                <th className="text-left py-2 px-3 font-medium">Description</th>
+                <th className="text-left py-2 px-3 font-medium">Category</th>
+                <th className="text-center py-2 px-3 font-medium">L</th>
+                <th className="text-center py-2 px-3 font-medium">I</th>
+                <th className="text-center py-2 px-3 font-medium">Score</th>
+                <th className="text-left py-2 px-3 font-medium">Owner</th>
+                <th className="text-left py-2 px-3 font-medium">Mitigation</th>
+                <th className="text-left py-2 px-3 font-medium">Status</th>
+                <th className="text-left py-2 px-3 font-medium">Review Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((r, i) => {
+                const score = r.likelihood * r.impact;
+                return (
+                  <tr key={r.id} className={`border-b hover:bg-muted/30 ${i % 2 === 0 ? "" : "bg-muted/10"}`}>
+                    <td className="py-2 px-3 font-mono text-red-700">{r.id}</td>
+                    <td className="py-2 px-3 max-w-[200px]">
+                      <p className="truncate" title={r.description}>{r.description}</p>
+                    </td>
+                    <td className="py-2 px-3">
+                      <span
+                        className="px-2 py-0.5 rounded-full text-white text-[10px] font-medium"
+                        style={{ backgroundColor: CATEGORY_COLORS[r.category] }}
+                      >
+                        {r.category}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 text-center font-bold">{r.likelihood}</td>
+                    <td className="py-2 px-3 text-center font-bold">{r.impact}</td>
+                    <td className="py-2 px-3 text-center">
+                      <span className={`px-2 py-0.5 rounded font-bold text-xs ${riskColor(score)}`}>
+                        {score}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3">{r.owner}</td>
+                    <td className="py-2 px-3 max-w-[180px]">
+                      <p className="truncate text-muted-foreground" title={r.mitigation}>{r.mitigation}</p>
+                    </td>
+                    <td className="py-2 px-3">
+                      <span className={`px-2 py-0.5 rounded-full border text-xs font-medium ${STATUS_COLORS[r.status]}`}>
+                        {r.status}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 text-muted-foreground">{r.reviewDate}</td>
+                  </tr>
+                );
+              })}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={10} className="py-8 text-center text-muted-foreground">
+                    No risks match your filters.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/qms/SuggestionTrackerTab.tsx
+++ b/components/qms/SuggestionTrackerTab.tsx
@@ -1,0 +1,543 @@
+// @ts-nocheck
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  MessageSquarePlus, CheckCircle2, Clock, XCircle, Eye, Download,
+  Users, TrendingUp, BarChart3, Star, Send, Lightbulb
+} from "lucide-react";
+import {
+  BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip, Legend, ResponsiveContainer, Cell
+} from "recharts";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type SuggestionStatus = "New" | "Under Review" | "Approved" | "Implemented" | "Rejected";
+type SuggestionCategory = "Process" | "Safety" | "Equipment" | "Quality" | "Cost" | "Environment" | "IT";
+
+interface Suggestion {
+  id: string;
+  submitter: string;
+  date: string;
+  category: SuggestionCategory;
+  description: string;
+  expectedBenefit: string;
+  status: SuggestionStatus;
+  reviewer?: string;
+  implementationDate?: string;
+  impact?: "High" | "Medium" | "Low";
+}
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const SUGGESTIONS: Suggestion[] = [
+  {
+    id: "SUG-001",
+    submitter: "Rajan Kumar",
+    date: "2025-10-05",
+    category: "Process",
+    description: "Introduce digital checklist on tablet for pre-test equipment verification to eliminate paper-based forms",
+    expectedBenefit: "Save 15 min/day per technician; reduce paper usage by 80%",
+    status: "Implemented",
+    reviewer: "Priya Sharma",
+    implementationDate: "2025-11-15",
+    impact: "High",
+  },
+  {
+    id: "SUG-002",
+    submitter: "Meena Pillai",
+    date: "2025-10-18",
+    category: "Safety",
+    description: "Install UV-blocking film on windows adjacent to UV aging test chamber",
+    expectedBenefit: "Reduce UV exposure risk for nearby workstations",
+    status: "Implemented",
+    reviewer: "Arvind Nair",
+    implementationDate: "2025-12-01",
+    impact: "High",
+  },
+  {
+    id: "SUG-003",
+    submitter: "Suresh Menon",
+    date: "2025-11-02",
+    category: "IT",
+    description: "Dashboard widget showing real-time chamber temperature and humidity via IoT sensors",
+    expectedBenefit: "Instant visibility; faster response to deviations; reduced manual monitoring",
+    status: "Approved",
+    reviewer: "Priya Sharma",
+    impact: "High",
+  },
+  {
+    id: "SUG-004",
+    submitter: "Kavya Reddy",
+    date: "2025-11-10",
+    category: "Cost",
+    description: "Negotiate bulk purchase agreement with calibration lab for 20% cost reduction",
+    expectedBenefit: "Save ₹30K annually on external calibration costs",
+    status: "Implemented",
+    reviewer: "Rajan Kumar",
+    implementationDate: "2026-01-01",
+    impact: "Medium",
+  },
+  {
+    id: "SUG-005",
+    submitter: "Arvind Nair",
+    date: "2025-11-22",
+    category: "Quality",
+    description: "Add uncertainty budget auto-calculation to IEC 60904-3 test report template",
+    expectedBenefit: "Reduce calculation errors; save 30 min per report",
+    status: "Under Review",
+    reviewer: "Meena Pillai",
+    impact: "High",
+  },
+  {
+    id: "SUG-006",
+    submitter: "Rajan Kumar",
+    date: "2025-12-03",
+    category: "Environment",
+    description: "Set up solar-powered charging station for lab equipment batteries to reduce grid consumption",
+    expectedBenefit: "Reduce lab electricity costs; improve sustainability metrics",
+    status: "Under Review",
+    reviewer: "Kavya Reddy",
+    impact: "Medium",
+  },
+  {
+    id: "SUG-007",
+    submitter: "Priya Sharma",
+    date: "2025-12-15",
+    category: "Process",
+    description: "Introduce weekly 5-minute stand-up meetings for cross-team test schedule alignment",
+    expectedBenefit: "Reduce scheduling conflicts by 50%; improve cross-team communication",
+    status: "Implemented",
+    reviewer: "Suresh Menon",
+    implementationDate: "2026-01-10",
+    impact: "Medium",
+  },
+  {
+    id: "SUG-008",
+    submitter: "Meena Pillai",
+    date: "2026-01-07",
+    category: "Equipment",
+    description: "Label all cable connections on sun simulator with color-coded tags for quick identification",
+    expectedBenefit: "Reduce setup errors; speed up troubleshooting",
+    status: "Approved",
+    reviewer: "Arvind Nair",
+    impact: "Low",
+  },
+  {
+    id: "SUG-009",
+    submitter: "Suresh Menon",
+    date: "2026-01-20",
+    category: "IT",
+    description: "Automated email alert when calibration due date is within 30 days",
+    expectedBenefit: "Zero missed calibrations; reduce manual tracking effort",
+    status: "Implemented",
+    reviewer: "Priya Sharma",
+    implementationDate: "2026-02-15",
+    impact: "High",
+  },
+  {
+    id: "SUG-010",
+    submitter: "Kavya Reddy",
+    date: "2026-02-01",
+    category: "Process",
+    description: "Create visual work instruction cards (laminated) for each test station",
+    expectedBenefit: "Faster onboarding of new staff; reduce SOP reference time",
+    status: "New",
+    impact: "Medium",
+  },
+  {
+    id: "SUG-011",
+    submitter: "Arvind Nair",
+    date: "2026-02-14",
+    category: "Quality",
+    description: "Implement statistical process control chart for I-V curve repeatability across simulators",
+    expectedBenefit: "Early detection of simulator drift; better IEC 60904-9 compliance",
+    status: "Under Review",
+    reviewer: "Meena Pillai",
+    impact: "High",
+  },
+  {
+    id: "SUG-012",
+    submitter: "Rajan Kumar",
+    date: "2026-02-25",
+    category: "Safety",
+    description: "Add emergency stop button accessible from both ends of the EL imaging station",
+    expectedBenefit: "Enhanced electrical safety; compliance with local safety regulations",
+    status: "Approved",
+    reviewer: "Kavya Reddy",
+    impact: "High",
+  },
+  {
+    id: "SUG-013",
+    submitter: "Priya Sharma",
+    date: "2026-03-05",
+    category: "Cost",
+    description: "Reuse packaging foam from incoming samples for outgoing shipments instead of buying new foam",
+    expectedBenefit: "Save ₹15K/year on packaging materials; reduce waste",
+    status: "New",
+    impact: "Low",
+  },
+  {
+    id: "SUG-014",
+    submitter: "Suresh Menon",
+    date: "2026-03-12",
+    category: "Process",
+    description: "Add a shared digital library of IEC/ISO standards accessible on lab intranet",
+    expectedBenefit: "Faster standard lookup; ensure everyone uses current versions",
+    status: "Rejected",
+    reviewer: "Rajan Kumar",
+    impact: "Medium",
+  },
+];
+
+const MONTHLY_SUGGESTIONS = [
+  { month: "Oct '25", new: 2, implemented: 0, rejected: 0 },
+  { month: "Nov '25", new: 4, implemented: 1, rejected: 0 },
+  { month: "Dec '25", new: 2, implemented: 2, rejected: 0 },
+  { month: "Jan '26", new: 3, implemented: 3, rejected: 0 },
+  { month: "Feb '26", new: 3, implemented: 2, rejected: 0 },
+  { month: "Mar '26", new: 2, implemented: 1, rejected: 1 },
+];
+
+const CATEGORY_COLORS: Record<SuggestionCategory, string> = {
+  Process: "#3b82f6",
+  Safety: "#ef4444",
+  Equipment: "#8b5cf6",
+  Quality: "#10b981",
+  Cost: "#f59e0b",
+  Environment: "#06b6d4",
+  IT: "#6366f1",
+};
+
+const STATUS_CONFIG: Record<SuggestionStatus, { color: string; icon: any }> = {
+  New: { color: "bg-blue-50 text-blue-700 border-blue-200", icon: MessageSquarePlus },
+  "Under Review": { color: "bg-amber-50 text-amber-700 border-amber-200", icon: Eye },
+  Approved: { color: "bg-purple-50 text-purple-700 border-purple-200", icon: CheckCircle2 },
+  Implemented: { color: "bg-green-50 text-green-700 border-green-200", icon: Star },
+  Rejected: { color: "bg-red-50 text-red-700 border-red-200", icon: XCircle },
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function SuggestionTrackerTab() {
+  const [search, setSearch] = useState("");
+  const [filterStatus, setFilterStatus] = useState<SuggestionStatus | "All">("All");
+  const [filterCategory, setFilterCategory] = useState<SuggestionCategory | "All">("All");
+  const [showForm, setShowForm] = useState(false);
+
+  const filtered = SUGGESTIONS.filter((s) => {
+    const matchSearch =
+      s.description.toLowerCase().includes(search.toLowerCase()) ||
+      s.submitter.toLowerCase().includes(search.toLowerCase()) ||
+      s.id.toLowerCase().includes(search.toLowerCase());
+    const matchStatus = filterStatus === "All" || s.status === filterStatus;
+    const matchCat = filterCategory === "All" || s.category === filterCategory;
+    return matchSearch && matchStatus && matchCat;
+  });
+
+  const implemented = SUGGESTIONS.filter((s) => s.status === "Implemented").length;
+  const implementationRate = Math.round((implemented / SUGGESTIONS.length) * 100);
+
+  // Top contributors
+  const contributorMap: Record<string, number> = {};
+  SUGGESTIONS.forEach((s) => {
+    contributorMap[s.submitter] = (contributorMap[s.submitter] ?? 0) + 1;
+  });
+  const topContributors = Object.entries(contributorMap)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 5);
+
+  const categoryData = (["Process", "Safety", "Equipment", "Quality", "Cost", "Environment", "IT"] as SuggestionCategory[]).map(
+    (cat) => ({
+      name: cat,
+      count: SUGGESTIONS.filter((s) => s.category === cat).length,
+      fill: CATEGORY_COLORS[cat],
+    })
+  );
+
+  const exportCSV = () => {
+    const rows = [
+      ["ID", "Submitter", "Date", "Category", "Description", "Expected Benefit", "Status", "Reviewer", "Implementation Date", "Impact"],
+      ...SUGGESTIONS.map((s) => [
+        s.id, s.submitter, s.date, s.category, s.description, s.expectedBenefit,
+        s.status, s.reviewer ?? "", s.implementationDate ?? "", s.impact ?? "",
+      ]),
+    ];
+    const csv = rows.map((r) => r.map((c) => `"${c}"`).join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a"); a.href = url; a.download = "suggestions.csv"; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header banner */}
+      <div className="flex items-center gap-2 text-xs text-muted-foreground bg-purple-50 border border-purple-200 rounded-lg px-3 py-2">
+        <Lightbulb className="h-4 w-4 text-purple-600 flex-shrink-0" />
+        <span>
+          <strong>Employee Suggestion System:</strong> Capturing lab improvement ideas from all staff in line with ISO 17025:2017 Clause 8.6 — continuous improvement culture.
+        </span>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Card className="border-l-4 border-l-blue-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Total Suggestions</div>
+            <div className="text-2xl font-bold">{SUGGESTIONS.length}</div>
+            <div className="text-xs text-muted-foreground">All time</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-green-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Implemented</div>
+            <div className="text-2xl font-bold text-green-700">{implemented}</div>
+            <div className="text-xs text-muted-foreground">{implementationRate}% implementation rate</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-amber-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Pending Review</div>
+            <div className="text-2xl font-bold text-amber-700">
+              {SUGGESTIONS.filter((s) => s.status === "New" || s.status === "Under Review").length}
+            </div>
+            <div className="text-xs text-muted-foreground">Awaiting decision</div>
+          </CardContent>
+        </Card>
+        <Card className="border-l-4 border-l-purple-500">
+          <CardContent className="pt-4 pb-3">
+            <div className="text-xs text-muted-foreground">Contributors</div>
+            <div className="text-2xl font-bold text-purple-700">{Object.keys(contributorMap).length}</div>
+            <div className="text-xs text-muted-foreground">Unique submitters</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Charts Row */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <Card className="lg:col-span-2">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <TrendingUp className="h-4 w-4 text-blue-600" /> Monthly Suggestion Trends
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={210}>
+              <LineChart data={MONTHLY_SUGGESTIONS} margin={{ top: 4, right: 20, left: -20, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                <XAxis dataKey="month" tick={{ fontSize: 10 }} />
+                <YAxis tick={{ fontSize: 10 }} />
+                <Tooltip />
+                <Legend wrapperStyle={{ fontSize: 11 }} />
+                <Line type="monotone" dataKey="new" name="Submitted" stroke="#3b82f6" strokeWidth={2} dot={{ r: 3 }} />
+                <Line type="monotone" dataKey="implemented" name="Implemented" stroke="#10b981" strokeWidth={2} dot={{ r: 3 }} />
+                <Line type="monotone" dataKey="rejected" name="Rejected" stroke="#ef4444" strokeWidth={2} dot={{ r: 3 }} />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Users className="h-4 w-4 text-purple-600" /> Top Contributors
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 pt-2">
+            {topContributors.map(([name, count], i) => (
+              <div key={name} className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground w-4">{i + 1}.</span>
+                <div className="flex-1 text-xs font-medium truncate">{name}</div>
+                <div className="flex items-center gap-1">
+                  <div
+                    className="h-2 rounded-full bg-purple-400"
+                    style={{ width: `${(count / topContributors[0][1]) * 60}px` }}
+                  />
+                  <span className="text-xs font-bold text-purple-700 w-4 text-right">{count}</span>
+                </div>
+              </div>
+            ))}
+            <div className="pt-2">
+              <div className="text-xs text-muted-foreground mb-2">By Category</div>
+              {categoryData.filter((c) => c.count > 0).map((cat) => (
+                <div key={cat.name} className="flex items-center gap-2 mb-1">
+                  <span className="text-[10px] text-muted-foreground w-16 truncate">{cat.name}</span>
+                  <div
+                    className="h-2 rounded-full"
+                    style={{ width: `${(cat.count / SUGGESTIONS.length) * 80}px`, backgroundColor: cat.fill }}
+                  />
+                  <span className="text-xs font-bold" style={{ color: cat.fill }}>{cat.count}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Suggestion Form (collapsible) */}
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <Send className="h-4 w-4 text-blue-600" /> Submit a New Suggestion
+            </CardTitle>
+            <Button size="sm" variant="outline" className="h-7 text-xs" onClick={() => setShowForm(!showForm)}>
+              {showForm ? "Hide Form" : "Open Form"}
+            </Button>
+          </div>
+        </CardHeader>
+        {showForm && (
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs font-medium mb-1 block">Submitter Name</label>
+                <Input placeholder="Your name" className="h-8 text-xs" />
+              </div>
+              <div>
+                <label className="text-xs font-medium mb-1 block">Category</label>
+                <select className="w-full h-8 text-xs border rounded px-2 bg-background">
+                  {["Process", "Safety", "Equipment", "Quality", "Cost", "Environment", "IT"].map((c) => (
+                    <option key={c}>{c}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="md:col-span-2">
+                <label className="text-xs font-medium mb-1 block">Suggestion Description</label>
+                <textarea
+                  placeholder="Describe your improvement suggestion in detail…"
+                  className="w-full h-20 text-xs border rounded px-2 py-1.5 bg-background resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+              </div>
+              <div className="md:col-span-2">
+                <label className="text-xs font-medium mb-1 block">Expected Benefit</label>
+                <Input placeholder="What benefit do you expect? (time saved, cost reduced, safety improved…)" className="h-8 text-xs" />
+              </div>
+              <div className="md:col-span-2 flex justify-end">
+                <Button size="sm" className="h-8 text-xs">
+                  <Send className="h-3 w-3 mr-1" /> Submit Suggestion
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        )}
+      </Card>
+
+      {/* Suggestions Table */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center justify-between">
+            <CardTitle className="text-sm flex items-center gap-2">
+              <BarChart3 className="h-4 w-4 text-blue-600" /> All Suggestions
+            </CardTitle>
+            <div className="flex flex-wrap gap-2 items-center">
+              <Input
+                placeholder="Search suggestions…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-7 text-xs w-44"
+              />
+              <select
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value as any)}
+                className="h-7 text-xs border rounded px-2 bg-background"
+              >
+                {["All", "New", "Under Review", "Approved", "Implemented", "Rejected"].map((s) => (
+                  <option key={s}>{s}</option>
+                ))}
+              </select>
+              <select
+                value={filterCategory}
+                onChange={(e) => setFilterCategory(e.target.value as any)}
+                className="h-7 text-xs border rounded px-2 bg-background"
+              >
+                {["All", "Process", "Safety", "Equipment", "Quality", "Cost", "Environment", "IT"].map((c) => (
+                  <option key={c}>{c}</option>
+                ))}
+              </select>
+              <Button size="sm" variant="outline" className="h-7 text-xs" onClick={exportCSV}>
+                <Download className="h-3 w-3 mr-1" /> Export
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="overflow-x-auto p-0">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b bg-muted/40">
+                <th className="text-left py-2 px-3 font-medium">ID</th>
+                <th className="text-left py-2 px-3 font-medium">Date</th>
+                <th className="text-left py-2 px-3 font-medium">Submitter</th>
+                <th className="text-left py-2 px-3 font-medium">Category</th>
+                <th className="text-left py-2 px-3 font-medium">Description</th>
+                <th className="text-left py-2 px-3 font-medium">Expected Benefit</th>
+                <th className="text-left py-2 px-3 font-medium">Impact</th>
+                <th className="text-left py-2 px-3 font-medium">Reviewer</th>
+                <th className="text-left py-2 px-3 font-medium">Impl. Date</th>
+                <th className="text-left py-2 px-3 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((s, i) => {
+                const cfg = STATUS_CONFIG[s.status];
+                const StatusIcon = cfg.icon;
+                return (
+                  <tr key={s.id} className={`border-b hover:bg-muted/30 ${i % 2 === 0 ? "" : "bg-muted/10"}`}>
+                    <td className="py-2 px-3 font-mono text-purple-700">{s.id}</td>
+                    <td className="py-2 px-3 text-muted-foreground">{s.date}</td>
+                    <td className="py-2 px-3 font-medium">{s.submitter}</td>
+                    <td className="py-2 px-3">
+                      <span
+                        className="px-2 py-0.5 rounded-full text-white text-[10px] font-medium"
+                        style={{ backgroundColor: CATEGORY_COLORS[s.category] }}
+                      >
+                        {s.category}
+                      </span>
+                    </td>
+                    <td className="py-2 px-3 max-w-[180px]">
+                      <p className="truncate" title={s.description}>{s.description}</p>
+                    </td>
+                    <td className="py-2 px-3 max-w-[140px]">
+                      <p className="truncate text-muted-foreground" title={s.expectedBenefit}>{s.expectedBenefit}</p>
+                    </td>
+                    <td className="py-2 px-3">
+                      {s.impact && (
+                        <span
+                          className={`text-xs font-medium ${
+                            s.impact === "High" ? "text-green-700" : s.impact === "Medium" ? "text-amber-700" : "text-gray-500"
+                          }`}
+                        >
+                          {s.impact}
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 px-3 text-muted-foreground">{s.reviewer ?? "—"}</td>
+                    <td className="py-2 px-3 text-muted-foreground">{s.implementationDate ?? "—"}</td>
+                    <td className="py-2 px-3">
+                      <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-xs font-medium ${cfg.color}`}>
+                        <StatusIcon className="h-3 w-3" />
+                        {s.status}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={10} className="py-8 text-center text-muted-foreground">
+                    No suggestions match your filters.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
- KaizenTab: continuous improvement tracking per ISO 17025 Clause 8.6
  - Improvement initiatives log with status, category, impact score
  - Before/After metrics visualization for completed events
  - Monthly trends stacked bar chart and category breakdown chart
  - KPI cards: total, completed, in-progress, proposed, avg impact

- RiskRegisterTab: risk assessment per ISO 17025 Clause 8.5
  - Interactive 5x5 likelihood vs impact risk matrix with color coding
  - Risk register table with score-based color highlighting
  - Top 5 risks dashboard and risk trend line chart
  - Export to CSV functionality

- SuggestionTrackerTab: employee suggestion tracking system
  - Submission form (submitter, category, description, expected benefit)
  - Status tracking (New/Under Review/Approved/Implemented/Rejected)
  - Statistics: total, implementation rate, top contributors
  - Monthly suggestion trends line chart and category breakdown
  - Export to CSV functionality

Wired all 3 tabs into QMS page TabsList/TabsContent with appropriate icons.

https://claude.ai/code/session_01N8WVkB6sgJfWWX4bt5NmJ3