### PR TITLE
Add tab state management to hide summary cards on Intermediate Checks tab

### DIFF
--- a/components/equipment/EquipmentDashboardClient.tsx
+++ b/components/equipment/EquipmentDashboardClient.tsx
@@ -56,6 +56,7 @@ export default function EquipmentDashboardClient() {
   const [formOpen, setFormOpen] = useState(false);
   const [editingEquipment, setEditingEquipment] = useState<Equipment | null>(null);
   const [statusChangeId, setStatusChangeId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("registry");
   const reportRef = useRef<HTMLDivElement>(null);
 
   // KPI computations
@@ -157,8 +158,8 @@ export default function EquipmentDashboardClient() {
         </div>
       </div>
 
-      {/* Summary Cards */}
-      <div ref={reportRef} className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3 print:grid-cols-7">
+      {/* Summary Cards - hidden when Intermediate Checks tab is active */}
+      {activeTab !== "intermediate-checks" && <div ref={reportRef} className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3 print:grid-cols-7">
         <Card>
           <CardContent className="p-3">
             <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Total Equipment</p>
@@ -201,10 +202,10 @@ export default function EquipmentDashboardClient() {
             <p className="text-xl font-bold text-foreground mt-0.5">{stats.avgAvail}%</p>
           </CardContent>
         </Card>
-      </div>
+      </div>}
 
       {/* Availability Rate KPIs per Category */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {activeTab !== "intermediate-checks" && <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-semibold">Equipment Utilization by Category</CardTitle>
@@ -280,10 +281,10 @@ export default function EquipmentDashboardClient() {
             </div>
           </CardContent>
         </Card>
-      </div>
+      </div>}
 
       {/* Availability Rate per Category */}
-      <Card className="print:break-before-page">
+      {activeTab !== "intermediate-checks" && <Card className="print:break-before-page">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-semibold">Availability Rate by Equipment Category</CardTitle>
         </CardHeader>
@@ -303,10 +304,10 @@ export default function EquipmentDashboardClient() {
             ))}
           </div>
         </CardContent>
-      </Card>
+      </Card>}
 
       {/* Tabs */}
-      <Tabs defaultValue="registry" className="space-y-4 print:hidden">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4 print:hidden">
         <TabsList>
           <TabsTrigger value="registry">Equipment Registry</TabsTrigger>
           <TabsTrigger value="calendar">Equipment Calendar</TabsTrigger>


### PR DESCRIPTION
## Summary
This PR adds tab state management to the Equipment Dashboard, allowing summary cards and KPI visualizations to be conditionally hidden when the "Intermediate Checks" tab is active, improving the UI/UX by reducing visual clutter on that specific tab.

## Key Changes
- Added `activeTab` state variable initialized to "registry" to track the currently active tab
- Converted the Tabs component from using `defaultValue` to controlled component pattern with `value` and `onValueChange` props
- Conditionally render summary cards section when `activeTab !== "intermediate-checks"`
- Conditionally render equipment utilization and availability rate KPI cards when `activeTab !== "intermediate-checks"`
- Conditionally render availability rate by category card when `activeTab !== "intermediate-checks"`

## Implementation Details
The changes use a simple state-based approach to control visibility of dashboard summary sections. When users navigate to the "Intermediate Checks" tab, the KPI cards and summary visualizations are hidden, while the tab content itself remains visible. This provides a cleaner interface for users focused on intermediate check data without losing the ability to view comprehensive analytics on other tabs.

https://claude.ai/code/session_01X1RX7nVjSMLE9UNJh97qJi