### PR TITLE
refactor(ci): add GitHub Actions CI pipeline — lint, type-check, build, audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Lint & Type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://ci:ci@localhost:5432/ci
+      NEXTAUTH_SECRET: ci-placeholder-not-real
+      NEXTAUTH_URL: http://localhost:3000
+      CLAUDE_API_KEY: sk-placeholder
+      ROBOFLOW_API_KEY: placeholder
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npm run build
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Audit (known failures in next@14 + xlsx tracked in #86 #87)
+        run: npm audit --audit-level=high
+        continue-on-error: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — three jobs that run on every push/PR targeting `main`
- Closes #90

## Jobs

| Job | Steps | Blocks merge? |
|---|---|---|
| **Lint & Type-check** | `npm ci` → `npm run lint` → `npx tsc --noEmit` | ✅ Yes |
| **Build** | `npm ci` → `npx prisma generate` → `npm run build` (dummy env vars) | ✅ Yes |
| **Security Audit** | `npm audit --audit-level=high` | ⚠️ `continue-on-error: true` |

The audit job is informational-only until the known CVEs in `next@14` (#86) and `xlsx` (#87) are resolved — making it a hard gate now would block every PR.

## Test plan

- [ ] Push a trivial commit to this branch and verify all three jobs appear in the Actions tab
- [ ] Confirm `quality` and `build` jobs complete (green or at worst a known env-var issue)
- [ ] Confirm `audit` job reports findings but does **not** mark the PR as failed

## Related

- Closes #90 (CI pipeline roadmap issue)
- Audit findings from this run will surface the CVEs already tracked in #86, #87, #88

## Monday refactor angle

Refactors the development process — zero-CI → three-job pipeline. Companion issue #94 tracks the next refactor: deduplicating `calculateNMOT` / `generateIrradianceTempModel` between `lib/iv-curve.ts` and `lib/nmot-noct.ts`.

https://claude.ai/code/session_018GpnsV3HtV68ejuajZoegj

---
_Generated by [Claude Code](https://claude.ai/code/session_018GpnsV3HtV68ejuajZoegj)_