### PR TITLE
enhance(ai): upgrade to claude-sonnet-4-6, normalize env vars, raise SOP token limit

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -100,7 +100,7 @@ async function* streamClaude(
       "anthropic-version": "2023-06-01",
     },
     body: JSON.stringify({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       max_tokens: 4096,
       stream: true,
       system: systemPrompt,

--- a/app/api/sop/generate/route.ts
+++ b/app/api/sop/generate/route.ts
@@ -24,10 +24,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const apiKey = process.env.CLAUDE_API_KEY;
+    const apiKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
     if (!apiKey) {
       return NextResponse.json(
-        { error: "CLAUDE_API_KEY not configured" },
+        { error: "ANTHROPIC_API_KEY not configured" },
         { status: 500 }
       );
     }
@@ -43,8 +43,8 @@ export async function POST(request: NextRequest) {
         "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify({
-        model: "claude-sonnet-4-20250514",
-        max_tokens: 4096,
+        model: "claude-sonnet-4-6",
+        max_tokens: 8192,
         messages: [
           {
             role: "user",
@@ -72,7 +72,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       sop,
       metadata: {
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         timestamp: new Date().toISOString(),
         standard,
         clause,


### PR DESCRIPTION
## Summary

Wednesday enhancement — AI route hardening (2026-05-06).

- **Model upgrade**: both `/api/chat` and `/api/sop/generate` now use `claude-sonnet-4-6` (was `claude-sonnet-4-20250514`, the retired Sonnet 4.5 alias)
- **Env-var normalization**: `/api/sop/generate` now checks `ANTHROPIC_API_KEY || CLAUDE_API_KEY`, matching the behaviour of `/api/chat`. Previously only `CLAUDE_API_KEY` was accepted, so deployments that set `ANTHROPIC_API_KEY` silently fell through to a 500.
- **Token limit**: `/api/sop/generate` `max_tokens` raised from 4096 → 8192. Complex SOPs (multi-step IEC 61215 sequences) were being silently truncated at the previous limit.

## Files changed

| File | Change |
|---|---|
| `app/api/chat/route.ts` | model → `claude-sonnet-4-6` |
| `app/api/sop/generate/route.ts` | model → `claude-sonnet-4-6`; env-var fallback; max_tokens 4096→8192; metadata updated |

## Test plan

- [ ] `/api/chat` — send a chat message with `ANTHROPIC_API_KEY` set; verify streaming response arrives and cites correct model
- [ ] `/api/sop/generate` — generate a full IEC 61215 TC200 SOP; verify response is not truncated and completes all 8 sections
- [ ] Set only `ANTHROPIC_API_KEY` (not `CLAUDE_API_KEY`) in env; verify SOP generation succeeds (previously 500)
- [ ] `npx tsc --noEmit` passes

## Weekly angle

Wednesday = Enhancement. Companion to the security work in PR #85 and the refactor in PR #93.

https://claude.ai/code/session_01L1YaErDopHrB1tSYeZHWac

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1YaErDopHrB1tSYeZHWac)_