### PR TITLE
docs(api): add GET /api/health liveness probe

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+
+const MODULES = [
+  'lims', 'qms', 'audit', 'projects', 'uncertainty',
+  'vision-ai', 'sop-gen', 'reports', 'sun-simulator',
+  'chamber-config', 'procurement',
+]
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    version: process.env.npm_package_version ?? '1.0.0',
+    timestamp: new Date().toISOString(),
+    modules: { count: MODULES.length, names: MODULES },
+    uptime_s: Math.round(process.uptime()),
+  })
+}


### PR DESCRIPTION
## Summary

**Friday angle — docs + ideation.** Exposes a stable liveness endpoint that documents the API surface and unblocks the smoke-test monitoring workflow described in issue #98.

- `GET /api/health` returns `200 OK` with JSON:
  ```json
  {
    "status": "ok",
    "version": "1.0.0",
    "timestamp": "2026-05-08T...",
    "modules": { "count": 11, "names": ["lims", "qms", ...] },
    "uptime_s": 42
  }
  ```
- One new file: `app/api/health/route.ts` (17 lines, no deps)
- Enables the `smoke-prod.yml` cron proposed in #98 (`curl -f .../api/health` every 6 h)
- Serves as living documentation: the `modules.names` array is the canonical list of active routes

## Test plan

- [ ] `curl http://localhost:3000/api/health` returns `{"status":"ok",...}`
- [ ] Vercel preview deployment responds 200
- [ ] `npx tsc --noEmit` passes
- [ ] After PR #95 (CI) merges, this route satisfies the smoke-test acceptance criterion in #98

## Related

- Closes part of #98 (smoke-test infrastructure — the missing `/api/health` route)
- Companion to #95 (CI pipeline) — once that workflow adds a smoke step, this route is the target

https://claude.ai/code/session_01YRWvy4YS5pV3KS4EF5pWDi

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRWvy4YS5pV3KS4EF5pWDi)_