### PR TITLE
fix(security): add HTTP security headers; bump postcss and uuid floors

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,34 @@
 /** @type {import('next').NextConfig} */
+
+const securityHeaders = [
+  // Block clickjacking
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  // Prevent MIME-type sniffing
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  // Force HTTPS for 2 years, include subdomains
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  // Limit referrer data sent to third parties
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // Disable unused browser features
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+];
+
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        // Apply to all routes
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {
@@ -8,7 +37,7 @@ const nextConfig = {
       },
     ],
   },
-  transpilePackages: ['@react-pdf/renderer'],
+  transpilePackages: ["@react-pdf/renderer"],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
-        "uuid": "^11.0.3",
+        "uuid": "^11.1.1",
         "xlsx": "^0.18.5",
         "zod": "^3.23.8"
       },
@@ -66,7 +66,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
         "eslint-config-next": "14.2.18",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.10",
         "prisma": "^5.22.0",
         "tailwindcss": "^3.4.15",
         "typescript": "^5.7.2"
@@ -7368,9 +7368,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -9275,9 +9275,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^11.0.3",
+    "uuid": "^11.1.1",
     "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
@@ -67,7 +67,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.18",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.10",
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.7.2"


### PR DESCRIPTION
## Summary

**Saturday angle — security.** Two non-breaking, self-contained hardening changes.

### 1. HTTP Security Headers (`next.config.mjs`)

Added five headers applied to every route via the `headers()` API:

| Header | Value | Threat mitigated |
|---|---|---|
| `X-Frame-Options` | `SAMEORIGIN` | Clickjacking |
| `X-Content-Type-Options` | `nosniff` | MIME-type sniffing attacks |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Downgrade / MITM |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer leakage |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), interest-cohort=()` | Feature abuse / FLoC |

CSP is intentionally omitted — it requires nonce/hash configuration for Next.js inline scripts and will be a separate PR once the app's script inventory is audited.

### 2. Direct dependency floor bumps (closes #102)

| Package | Before | After | Advisory cleared |
|---|---|---|---|
| `postcss` | `^8.4.49` | `^8.5.10` | GHSA-qx2v-qp2m-jg93 (moderate) |
| `uuid` | `^11.0.3` | `^11.1.1` | GHSA-w5hq-g745-h8pq (moderate) |

Installed versions: `postcss@8.5.14`, `uuid@11.1.1`. Both are within the existing `^` range so this is non-breaking.

The transitive `postcss@8.4.31` inside `next@14.2.18` cannot be bumped here — it resolves when #86 (Next.js upgrade) lands.

## Related issues

- Closes #102 (postcss + uuid moderate advisories)
- See also #103 (new this week) — unauthenticated AI API routes; separate PR needed
- See #86 (Next.js CRITICAL), #87 (xlsx HIGH), #88 (dompurify MODERATE) — still open

## Test plan

- [ ] `npm run build` passes with no new errors
- [ ] Vercel preview deployment: check Response Headers in DevTools → all 5 headers present on any page
- [ ] Login flow still works (headers don't break auth redirects)
- [ ] `npm audit --audit-level=moderate` no longer reports postcss or uuid for direct deps

https://claude.ai/code/session_01X9CHikXamgPic7BfsHyfmK

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9CHikXamgPic7BfsHyfmK)_