### PR TITLE
chore(bulk-removal): remove debug console.log from LIMS test detail page

### DIFF
--- a/app/(dashboard)/lims/tests/[id]/page.tsx
+++ b/app/(dashboard)/lims/tests/[id]/page.tsx
@@ -111,7 +111,7 @@ export default function TestDetailPage() {
           <TestTemplateRenderer
             template={template}
             initialData={test.inputData}
-            onSubmit={(data) => console.log('Test data submitted:', data)}
+            onSubmit={() => {}}
             readOnly={test.status === 'completed'}
           />
         </div>


### PR DESCRIPTION
## Summary

**Tuesday bulk-removal angle — 2026-05-12.**

Single targeted removal: the `onSubmit` handler on `TestTemplateRenderer` in the LIMS test detail page was a debug stub that called `console.log('Test data submitted:', data)` — logging the full form payload to the browser console in every environment, including production.

### Change

| File | Line | Before | After |
|---|---|---|---|
| `app/(dashboard)/lims/tests/[id]/page.tsx` | 114 | `onSubmit={(data) => console.log('Test data submitted:', data)}` | `onSubmit={() => {}}` |

### Why a no-op, not a real handler?

The real save handler requires a working database connection (issue #91 — Prisma/Supabase not yet wired). Replacing with a no-op now stops the data leak; the functional handler will be added as part of #91 when API routes are connected.

### Related

- Companion issue filed: **#110** — `@ts-nocheck` epidemic (381 suppressions) — broader Tuesday bulk-removal backlog item
- See #91 for the real `onSubmit` implementation (LIMS DB connectivity)
- See #98 for the missing CI pipeline that would have caught this via `no-console` ESLint rule

## Test plan

- [ ] Open `/lims/tests/<any-id>` → fill in test template fields → submit → no console output
- [ ] Completed tests still render as `readOnly` (no regression)
- [ ] `npx tsc --noEmit` passes

https://claude.ai/code/session_01LL2vQW6swf278kRGKPGayH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL2vQW6swf278kRGKPGayH)_