### PR TITLE
enhance(ai): migrate to @anthropic-ai/sdk 0.54, add prompt caching to AI routes

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
 
 // ---------------------------------------------------------------------------
 // POST /api/chat – RAG-powered chat endpoint
@@ -83,63 +84,74 @@ async function embedText(text: string): Promise<number[]> {
   return data.data?.[0]?.embedding ?? [];
 }
 
-// ---- Claude streaming helper -----------------------------------------------
+// ---- Claude streaming helper (Anthropic SDK + prompt caching) --------------
+
+// Static portion of the system prompt — sent with cache_control so the
+// ~600-token expert-persona block is cached across requests.
+const STATIC_SOLAR_SYSTEM = `You are SolarLabX AI Assistant, an expert in solar PV testing laboratory operations, IEC/ISO standards, and quality management systems.
+
+Your knowledge covers:
+- IEC 61215 (Design Qualification), IEC 61730 (Safety), IEC 61853 (Energy Rating)
+- IEC 60904 (Measurement Procedures), IEC 60891 (I-V Translation)
+- IEC 62915 (Type Test Sample Requirements), IEC 62788 (Material Testing)
+- IEC 62804 (PID), IEC 61701 (Salt Mist), IEC 62716 (Ammonia)
+- ISO/IEC 17025 (Lab Competence), ISO 9001 (Quality Management)
+- GUM (Guide to Uncertainty in Measurement)
+- NABL, ILAC, BIS compliance requirements
+
+Guidelines:
+- Provide technically accurate, detailed answers with specific clause/section references
+- Use markdown formatting with tables where appropriate
+- When citing standards, include edition year and specific clause numbers
+- If the context doesn't fully answer the question, supplement with your knowledge but note this
+- For procedural questions, include step-by-step instructions with acceptance criteria
+- Always mention relevant SolarLabX modules that can help (e.g., Uncertainty Calculator, LIMS, etc.)`;
 
 async function* streamClaude(
-  systemPrompt: string,
+  ragContext: string,
   messages: { role: string; content: string }[]
 ): AsyncGenerator<string> {
   const apiKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
   if (!apiKey) throw new Error("NO_API_KEY");
 
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 4096,
-      stream: true,
-      system: systemPrompt,
-      messages,
-    }),
-  });
+  const client = new Anthropic({ apiKey });
 
-  if (!res.ok) {
-    const err = await res.text();
-    console.error("Claude API error:", err);
-    throw new Error(`Claude API ${res.status}`);
+  // Build system blocks: stable part (cached) + dynamic RAG context (uncached).
+  const system: Array<{
+    type: "text";
+    text: string;
+    cache_control?: { type: "ephemeral" };
+  }> = [
+    {
+      type: "text",
+      text: STATIC_SOLAR_SYSTEM,
+      cache_control: { type: "ephemeral" },
+    },
+  ];
+  if (ragContext) {
+    system.push({
+      type: "text",
+      text: `## Retrieved Context from Knowledge Base\nUse the following retrieved information to ground your answer. Cite the source references.\n\n${ragContext}`,
+    });
   }
 
-  const reader = res.body?.getReader();
-  if (!reader) throw new Error("No response body");
+  const stream = await client.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 4096,
+    stream: true,
+    system,
+    messages: messages.map((m) => ({
+      role: m.role as "user" | "assistant",
+      content: m.content,
+    })),
+  });
 
-  const decoder = new TextDecoder();
-  let buf = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buf += decoder.decode(value, { stream: true });
-
-    const lines = buf.split("\n");
-    buf = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (!line.startsWith("data: ")) continue;
-      const payload = line.slice(6).trim();
-      if (payload === "[DONE]") return;
-      try {
-        const evt = JSON.parse(payload);
-        if (evt.type === "content_block_delta" && evt.delta?.text) {
-          yield evt.delta.text;
-        }
-      } catch {
-        // ignore non-JSON lines
-      }
+  for await (const event of stream) {
+    if (
+      event.type === "content_block_delta" &&
+      event.delta.type === "text_delta"
+    ) {
+      yield event.delta.text;
     }
   }
 }
@@ -518,27 +530,8 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Build system prompt
-    const systemPrompt = `You are SolarLabX AI Assistant, an expert in solar PV testing laboratory operations, IEC/ISO standards, and quality management systems.
-
-Your knowledge covers:
-- IEC 61215 (Design Qualification), IEC 61730 (Safety), IEC 61853 (Energy Rating)
-- IEC 60904 (Measurement Procedures), IEC 60891 (I-V Translation)
-- IEC 62915 (Type Test Sample Requirements), IEC 62788 (Material Testing)
-- IEC 62804 (PID), IEC 61701 (Salt Mist), IEC 62716 (Ammonia)
-- ISO/IEC 17025 (Lab Competence), ISO 9001 (Quality Management)
-- GUM (Guide to Uncertainty in Measurement)
-- NABL, ILAC, BIS compliance requirements
-
-${ragContext ? `\n## Retrieved Context from Knowledge Base\nUse the following retrieved information to ground your answer. Cite the source references.\n\n${ragContext}\n` : ""}
-
-Guidelines:
-- Provide technically accurate, detailed answers with specific clause/section references
-- Use markdown formatting with tables where appropriate
-- When citing standards, include edition year and specific clause numbers
-- If the context doesn't fully answer the question, supplement with your knowledge but note this
-- For procedural questions, include step-by-step instructions with acceptance criteria
-- Always mention relevant SolarLabX modules that can help (e.g., Uncertainty Calculator, LIMS, etc.)`;
+    // ragContext is passed directly into streamClaude; STATIC_SOLAR_SYSTEM is
+    // the cached constant defined at module level.
 
     // Build messages array
     const claudeMessages = [
@@ -554,7 +547,7 @@ Guidelines:
     const stream = new ReadableStream({
       async start(controller) {
         try {
-          for await (const text of streamClaude(systemPrompt, claudeMessages)) {
+          for await (const text of streamClaude(ragContext, claudeMessages)) {
             controller.enqueue(
               encoder.encode(
                 `data: ${JSON.stringify({ type: "text", data: text })}\n\n`

--- a/app/api/sop/generate/route.ts
+++ b/app/api/sop/generate/route.ts
@@ -1,110 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
 
-/**
- * POST /api/sop/generate
- * Generate a Standard Operating Procedure using Claude API.
- *
- * Accepts JSON body with:
- * - standard: The IEC/ISO standard identifier
- * - clause: The specific clause/test method
- * - title: SOP title
- * - additionalContext: Optional additional context
- * - labName: Laboratory name
- * - documentNumber: Optional SOP document number
- */
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { standard, clause, title, additionalContext, labName, documentNumber } = body;
-
-    if (!standard || !clause || !title) {
-      return NextResponse.json(
-        { error: "standard, clause, and title are required" },
-        { status: 400 }
-      );
-    }
-
-    const apiKey = process.env.CLAUDE_API_KEY;
-    if (!apiKey) {
-      return NextResponse.json(
-        { error: "CLAUDE_API_KEY not configured" },
-        { status: 500 }
-      );
-    }
-
-    const prompt = buildSOPPrompt({ standard, clause, title, additionalContext, labName, documentNumber });
-
-    // Call Claude API
-    const claudeResponse = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: "claude-sonnet-4-20250514",
-        max_tokens: 4096,
-        messages: [
-          {
-            role: "user",
-            content: prompt,
-          },
-        ],
-      }),
-    });
-
-    if (!claudeResponse.ok) {
-      const errorText = await claudeResponse.text();
-      console.error("Claude API error:", errorText);
-      return NextResponse.json(
-        { error: `Claude API error: ${claudeResponse.status}` },
-        { status: 502 }
-      );
-    }
-
-    const claudeData = await claudeResponse.json();
-    const responseText = claudeData.content?.[0]?.text || "";
-
-    // Parse the structured SOP from Claude's response
-    const sop = parseSOPResponse(responseText, { title, standard, clause, labName, documentNumber });
-
-    return NextResponse.json({
-      sop,
-      metadata: {
-        model: "claude-sonnet-4-20250514",
-        timestamp: new Date().toISOString(),
-        standard,
-        clause,
-      },
-    });
-  } catch (error) {
-    console.error("SOP generation error:", error);
-    return NextResponse.json(
-      { error: "Internal server error during SOP generation" },
-      { status: 500 }
-    );
-  }
-}
-
-interface SOPPromptParams {
-  standard: string;
-  clause: string;
-  title: string;
-  additionalContext: string;
-  labName: string;
-  documentNumber: string;
-}
-
-function buildSOPPrompt(params: SOPPromptParams): string {
-  return `You are an expert in solar PV testing laboratory operations and ISO/IEC standards. Generate a comprehensive Standard Operating Procedure (SOP) for a solar PV testing laboratory.
-
-STANDARD: ${params.standard}
-CLAUSE/TEST METHOD: ${params.clause}
-SOP TITLE: ${params.title}
-LABORATORY: ${params.labName || "Solar PV Testing Laboratory"}
-${params.documentNumber ? `DOCUMENT NUMBER: ${params.documentNumber}` : ""}
-${params.additionalContext ? `ADDITIONAL CONTEXT: ${params.additionalContext}` : ""}
+// Stable expert persona — eligible for prompt caching on every call.
+const SOLAR_EXPERT_SYSTEM = `You are an expert in solar PV testing laboratory operations and ISO/IEC standards. Generate a comprehensive Standard Operating Procedure (SOP) for a solar PV testing laboratory.
 
 Generate the SOP with the following sections. Use clear, precise technical language appropriate for a NABL/ISO 17025 accredited laboratory. Include specific procedural steps, acceptance criteria where applicable, and reference standard clauses.
 
@@ -135,12 +33,110 @@ REVISION_HISTORY:
 [content]
 
 Ensure the procedure section is detailed with specific steps, temperatures, durations, and acceptance criteria from the standard. Include safety precautions where relevant.`;
+
+/**
+ * POST /api/sop/generate
+ * Generate a Standard Operating Procedure using the Anthropic SDK.
+ * The stable expert system prompt is sent with cache_control so repeat
+ * calls within the cache TTL skip re-tokenising the ~800-token system block.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const {
+      standard,
+      clause,
+      title,
+      additionalContext,
+      labName,
+      documentNumber,
+    } = body;
+
+    if (!standard || !clause || !title) {
+      return NextResponse.json(
+        { error: "standard, clause, and title are required" },
+        { status: 400 }
+      );
+    }
+
+    const apiKey =
+      process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "ANTHROPIC_API_KEY not configured" },
+        { status: 500 }
+      );
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    const userPrompt = [
+      `STANDARD: ${standard}`,
+      `CLAUSE/TEST METHOD: ${clause}`,
+      `SOP TITLE: ${title}`,
+      `LABORATORY: ${labName || "Solar PV Testing Laboratory"}`,
+      documentNumber ? `DOCUMENT NUMBER: ${documentNumber}` : "",
+      additionalContext ? `ADDITIONAL CONTEXT: ${additionalContext}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 8192,
+      system: [
+        {
+          type: "text",
+          text: SOLAR_EXPERT_SYSTEM,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [{ role: "user", content: userPrompt }],
+    });
+
+    const responseText =
+      response.content[0]?.type === "text" ? response.content[0].text : "";
+
+    const sop = parseSOPResponse(responseText, {
+      title,
+      standard,
+      clause,
+      labName,
+      documentNumber,
+    });
+
+    return NextResponse.json({
+      sop,
+      metadata: {
+        model: "claude-sonnet-4-6",
+        timestamp: new Date().toISOString(),
+        standard,
+        clause,
+        cache_read_tokens: response.usage?.cache_read_input_tokens ?? 0,
+      },
+    });
+  } catch (error) {
+    console.error("SOP generation error:", error);
+    return NextResponse.json(
+      { error: "Internal server error during SOP generation" },
+      { status: 500 }
+    );
+  }
 }
 
-function parseSOPResponse(
-  text: string,
-  meta: { title: string; standard: string; clause: string; labName: string; documentNumber: string }
-) {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SOPMeta {
+  title: string;
+  standard: string;
+  clause: string;
+  labName: string;
+  documentNumber: string;
+}
+
+function parseSOPResponse(text: string, meta: SOPMeta) {
   const sections: Record<string, string> = {
     purpose: "",
     scope: "",
@@ -163,7 +159,6 @@ function parseSOPResponse(
     { pattern: /REVISION[_\s]HISTORY:\s*/i, key: "revisionHistory" },
   ];
 
-  // Find positions of each section header
   const positions: { key: string; index: number }[] = [];
   for (const { pattern, key } of sectionKeys) {
     const match = text.match(pattern);
@@ -171,21 +166,18 @@ function parseSOPResponse(
       positions.push({ key, index: match.index + match[0].length });
     }
   }
-
-  // Sort by position
   positions.sort((a, b) => a.index - b.index);
 
-  // Extract content between headers
   for (let i = 0; i < positions.length; i++) {
     const start = positions[i].index;
-    const end = i + 1 < positions.length ? positions[i + 1].index : text.length;
-    // Find the start of the next section header (go back to find the header)
-    let endPos = end;
+    let endPos =
+      i + 1 < positions.length ? positions[i + 1].index : text.length;
     if (i + 1 < positions.length) {
-      // Find the actual header text before the next section
       const nextKey = sectionKeys.find((s) => s.key === positions[i + 1].key);
       if (nextKey) {
-        const headerMatch = text.substring(positions[i].index).match(nextKey.pattern);
+        const headerMatch = text
+          .substring(positions[i].index)
+          .match(nextKey.pattern);
         if (headerMatch && headerMatch.index !== undefined) {
           endPos = positions[i].index + headerMatch.index;
         }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
+    "@anthropic-ai/sdk": "^0.54.0",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",


### PR DESCRIPTION
## Summary

**Wednesday enhancement — 2026-05-13.**

Three related improvements delivered in one commit:

- **SDK adoption:** `@anthropic-ai/sdk` was already in `package.json` at `^0.39.0` but never imported — both AI routes used raw `fetch` with manual SSE parsing. This PR actually uses the SDK (`^0.54.0`) in both routes.
- **Prompt caching:** The stable system-prompt blocks (expert persona + guidelines) are now marked `cache_control: { type: "ephemeral" }`, so repeat calls within the 5-minute cache TTL skip re-tokenising ~600–800 tokens — roughly a 90% discount on those input tokens.
- **Model fix:** Both routes used `claude-sonnet-4-20250514` (a retired alias). Now `claude-sonnet-4-6`.

### Files changed

| File | Key change |
|---|---|
| `package.json` | `@anthropic-ai/sdk ^0.39.0 → ^0.54.0` |
| `app/api/sop/generate/route.ts` | SDK + caching + env-var fix + max_tokens 4096→8192 |
| `app/api/chat/route.ts` | SDK streaming + split static/dynamic system blocks + caching |

### `/api/sop/generate` detail

- Raw `fetch` → `client.messages.create()`
- `SOLAR_EXPERT_SYSTEM` constant (~800 tokens) sent with `cache_control: { type: "ephemeral" }`
- Env-var: was `CLAUDE_API_KEY` only → now `ANTHROPIC_API_KEY || CLAUDE_API_KEY`
- `max_tokens` 4096 → 8192 (long IEC 61215 SOPs were silently truncated)
- Response metadata includes `cache_read_tokens` for cost observability

### `/api/chat` detail

- `streamClaude()` replaced: raw SSE loop → SDK `messages.create({ stream: true })`
- System split into two blocks:
  - `STATIC_SOLAR_SYSTEM` (~600 tokens, `cache_control: ephemeral`) — fixed expert persona
  - Dynamic RAG context block (variable, uncached) — only appended when Pinecone returns results
- Demo/mock path unchanged (no API key)

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] `POST /api/sop/generate` with `ANTHROPIC_API_KEY` set returns a full SOP without truncation
- [ ] `POST /api/sop/generate` with only `ANTHROPIC_API_KEY` (not `CLAUDE_API_KEY`) — succeeds (previously 500)
- [ ] `POST /api/chat` streams a response; browser chat UI works end-to-end
- [ ] Second consecutive SOP request: `cache_read_tokens > 0` in response metadata

## Related

- Supersedes model-name portion of draft PR #96 (also updates model; this adds SDK + caching on top)
- Part of #89 (full SDK upgrade to 0.92.x still tracked there — this is a stepping stone)
- No conflict with security PRs #104, #108

https://claude.ai/code/session_01JiYiTodWaQqD5Mq3ge4iJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiYiTodWaQqD5Mq3ge4iJ6)_