### PR TITLE
docs(solvers): JSDoc for iv-curve and nmot-noct exported functions

### DIFF
--- a/lib/iv-curve.ts
+++ b/lib/iv-curve.ts
@@ -1,4 +1,10 @@
-// IV Curve Analysis utilities for Solar PV testing
+/**
+ * IV Curve Analysis — Solar PV testing utilities
+ *
+ * Provides single-diode curve generation, parameter extraction, and
+ * temperature/irradiance correction to STC (25 °C, 1000 W/m²) and NMOT
+ * conditions per IEC 60904-1 and IEC 61215.
+ */
 
 export const CURVE_COLORS = [
   '#f97316', '#3b82f6', '#22c55e', '#ef4444', '#a855f7',
@@ -74,7 +80,16 @@ export interface NMOTResult {
   tempDelta: number
 }
 
-// Generate a realistic IV curve using single-diode model
+/**
+ * Generate a discretised I-V curve using a simplified single-diode model.
+ *
+ * @param isc       - Short-circuit current (A)
+ * @param voc       - Open-circuit voltage (V)
+ * @param impp      - Current at maximum power point (A)
+ * @param vmpp      - Voltage at maximum power point (V)
+ * @param numPoints - Number of V-I samples; default 100
+ * @returns Ordered array of `{ voltage, current, power }` from V = 0 to Voc
+ */
 export function generateIVCurve(
   isc: number,
   voc: number,
@@ -105,13 +120,13 @@ export function generateIVCurve(
   return points
 }
 
-// Calculate series resistance from IV curve
+/** Estimate series resistance (Ω) from the slope near Voc. */
 export function calcSeriesResistance(voc: number, vmpp: number, impp: number, isc: number): number {
   // Approximate Rs from slope near Voc
   return parseFloat(((voc - vmpp) / impp - (voc - vmpp) / (isc - impp) * 0.5).toFixed(4))
 }
 
-// Calculate shunt resistance from IV curve
+/** Estimate shunt resistance (Ω) from the slope in the low-voltage region near Isc. */
 export function calcShuntResistance(voc: number, isc: number, points: IVDataPoint[]): number {
   // Approximate Rsh from slope near Isc (low voltage region)
   if (points.length < 5) return 1000
@@ -123,7 +138,7 @@ export function calcShuntResistance(voc: number, isc: number, points: IVDataPoin
   return parseFloat(Math.abs(dv / di).toFixed(2))
 }
 
-// Calculate diode ideality factor
+/** Estimate diode ideality factor (1–2) from the one-diode model equation. */
 export function calcIdealityFactor(voc: number, isc: number, vmpp: number, impp: number, temp: number): number {
   const k = 1.381e-23 // Boltzmann constant
   const q = 1.602e-19 // electron charge
@@ -134,7 +149,16 @@ export function calcIdealityFactor(voc: number, isc: number, vmpp: number, impp:
   return parseFloat(Math.max(1, Math.min(2, n)).toFixed(3))
 }
 
-// Temperature correction scalar (pmax only) to STC (25°C, 1000 W/m²)
+/**
+ * Scalar Pmax correction to STC (25 °C, 1000 W/m²) using a single
+ * temperature coefficient.  Use {@link correctToSTC} for a full curve.
+ *
+ * @param pmax          - Measured maximum power (W)
+ * @param irradiance    - Measured irradiance (W/m²)
+ * @param temperature   - Measured cell/module temperature (°C)
+ * @param tempCoeffPmax - Pmax temperature coefficient (%/°C, typically negative)
+ * @returns Pmax corrected to STC (W)
+ */
 export function correctPmaxToSTC(
   pmax: number,
   irradiance: number,
@@ -146,7 +170,13 @@ export function correctPmaxToSTC(
   return parseFloat((pmax * irradianceCorrection * tempCorrection).toFixed(2))
 }
 
-// Correct a full IV curve to STC conditions
+/**
+ * Translate a full IV curve to STC (25 °C, 1000 W/m²) using linear
+ * temperature coefficients per IEC 60904-1.
+ *
+ * Note: reads `params.tempCoeffPmax/Voc/Isc`; the alias fields
+ * `gammaPmax/betaVoc/alphaIsc` are unified in draft PR #93.
+ */
 export function correctToSTC(curve: IVCurveData, params: TemperatureCorrectionParams): IVCurveData {
   const tempDelta = 25 - curve.temperature
   const irradianceRatio = 1000 / curve.irradiance
@@ -213,7 +243,13 @@ export function generateIrradianceTempModel(
   return data
 }
 
-// Extract IV parameters from raw data points
+/**
+ * Derive key IV parameters (Voc, Isc, Pmax, Vmpp, Impp, FF, Rs, Rsh, n)
+ * from a raw array of measured data points.
+ *
+ * Assumes `points[0]` is at V = 0 (Isc) and the last point is at I = 0 (Voc).
+ * Returns all-zero values for an empty input rather than throwing.
+ */
 export function extractIVParameters(points: IVDataPoint[]): Pick<IVCurveData, 'voc' | 'isc' | 'pmax' | 'vmpp' | 'impp' | 'ff' | 'rSeries' | 'rShunt' | 'ideality'> {
   if (points.length === 0) {
     return { voc: 0, isc: 0, pmax: 0, vmpp: 0, impp: 0, ff: 0, rSeries: 0, rShunt: 0, ideality: 1 }
@@ -231,7 +267,11 @@ export function extractIVParameters(points: IVDataPoint[]): Pick<IVCurveData, 'v
   return { voc, isc, pmax, vmpp, impp, ff, rSeries, rShunt, ideality }
 }
 
-// Correct an IV curve to NMOT conditions
+/**
+ * Translate a full IV curve to NMOT operating conditions
+ * (T_amb + Ross model cell temperature, specified irradiance)
+ * using linear temperature coefficients per IEC 60904-1.
+ */
 export function correctToNMOT(curve: IVCurveData, params: TemperatureCorrectionParams): IVCurveData {
   const tMod = params.tAmbient + ((params.nmot - 20) * params.irradiance / 800)
   const tempDelta = tMod - 25

--- a/lib/nmot-noct.ts
+++ b/lib/nmot-noct.ts
@@ -1,4 +1,14 @@
-// NMOT/NOCT Calculator per IEC 61215 and IEC 61853
+/**
+ * NMOT/NOCT Calculator — IEC 61215:2021 and IEC 61853-2
+ *
+ * Computes Nominal Module Operating Temperature (NMOT) and the related
+ * cell-temperature model for any combination of irradiance, ambient
+ * temperature, wind speed, and mounting configuration.  NMOT supersedes
+ * the older NOCT metric in the 2021 edition of IEC 61215.
+ *
+ * Reference conditions for NMOT measurement:
+ *   G = 800 W/m², T_amb = 20 °C, wind = 1 m/s, open-rack mounting
+ */
 
 export interface NMOTInput {
   nocTmeasured: number;   // Measured NOCT (°C) from IEC 61215 MQT 05
@@ -40,7 +50,14 @@ const MOUNTING_CORRECTIONS: Record<string, number> = {
   bipv: 6,
 };
 
-// Calculate NMOT per IEC 61215:2021 (replaces NOCT)
+/**
+ * Derive NMOT from a measured NOCT value, applying mounting-type and
+ * wind-speed corrections per IEC 61215:2021 Annex A.
+ *
+ * @param input - Measurement inputs including measured NOCT, wind speed,
+ *   and mounting type (open_rack | close_roof | bipv)
+ * @returns NMOT in °C
+ */
 export function calculateNMOT(input: NMOTInput): number {
   const correction = MOUNTING_CORRECTIONS[input.mountingType] || 0;
   // NMOT = NOCT_measured + correction - (for wind speed difference)
@@ -49,12 +66,21 @@ export function calculateNMOT(input: NMOTInput): number {
   return input.nocTmeasured + correction + windCorrection;
 }
 
-// Calculate NOCT (legacy per IEC 61215:2005)
+/** Legacy NOCT with mounting correction per IEC 61215:2005. Prefer {@link calculateNMOT} for new work. */
 export function calculateNOCT(measuredNOCT: number, mountingType: string): number {
   return measuredNOCT + (MOUNTING_CORRECTIONS[mountingType] || 0);
 }
 
-// Calculate cell temperature at any operating conditions
+/**
+ * Cell temperature via the Ross model (IEC 61853-2 §6.3):
+ *   Tc = Ta + (NMOT − 20) × (G / 800) × windFactor
+ *
+ * @param ambientTemp - Ambient air temperature (°C)
+ * @param irradiance  - In-plane irradiance (W/m²)
+ * @param nmot        - Module NMOT (°C)
+ * @param windSpeed   - Wind speed (m/s); default 1 m/s (NMOT reference)
+ * @returns Cell temperature (°C)
+ */
 export function calculateCellTemp(
   ambientTemp: number,
   irradiance: number,
@@ -67,7 +93,16 @@ export function calculateCellTemp(
   return ambientTemp + (nmot - 20) * (irradiance / 800) * windFactor;
 }
 
-// Calculate performance at NMOT/NOCT conditions
+/**
+ * Compute module output parameters at NMOT reference conditions
+ * (G = 800 W/m², T_amb = 20 °C) using linear temperature coefficients.
+ *
+ * @param moduleSpecs - STC electrical specs and temperature coefficients
+ * @param nmot        - NMOT of the module (°C)
+ * @param irradiance  - Operating irradiance (W/m²); default 800 (NMOT ref)
+ * @returns Full {@link NMOTResult} including corrected Pmax, Voc, Isc,
+ *   performance ratio, and temperature derating factor
+ */
 export function calculatePerformanceAtNMOT(
   moduleSpecs: ModuleSpecs,
   nmot: number,
@@ -97,7 +132,15 @@ export function calculatePerformanceAtNMOT(
   };
 }
 
-// Generate irradiance vs temperature model data for charting
+/**
+ * Build a 2-D grid of cell temperatures for every combination of
+ * ambient temperature and irradiance — useful for heatmap charting.
+ *
+ * @param nmot         - Module NMOT (°C)
+ * @param ambientTemps - Array of ambient temperatures to sweep (°C)
+ * @param irradiances  - Array of irradiance levels to sweep (W/m²)
+ * @returns Flat array of `{ ambient, irradiance, cellTemp }` records
+ */
 export function generateIrradianceTempModel(
   nmot: number,
   ambientTemps: number[] = [0, 10, 20, 30, 40, 50],
@@ -116,7 +159,16 @@ export function generateIrradianceTempModel(
   return data;
 }
 
-// Generate performance ratio curve across temperatures
+/**
+ * Generate a performance-ratio curve across a range of ambient temperatures
+ * at 800 W/m² (NMOT irradiance reference).  The PR is expressed as a
+ * percentage of STC Pmax scaled to 800 W/m².
+ *
+ * @param moduleSpecs - STC specs and temperature coefficients
+ * @param nmot        - Module NMOT (°C)
+ * @param tempRange   - Ambient temperatures to evaluate (°C); default −10…50
+ * @returns Array of `{ ambient, cellTemp, pr, power }` records
+ */
 export function generatePRCurve(
   moduleSpecs: ModuleSpecs,
   nmot: number,


### PR DESCRIPTION
## Summary

**Friday angle — 2026-05-15 (docs + ideation).**

Both `lib/iv-curve.ts` and `lib/nmot-noct.ts` are covered by 87+ unit tests (PRs #97 and #113) but had minimal inline documentation. This PR adds structured JSDoc so IDE tooling (hover types, parameter hints) and future contributors get the full picture without reading the implementation.

### `lib/nmot-noct.ts`

| Symbol | Documentation added |
|---|---|
| Module | Reference conditions for NMOT per IEC 61215:2021; supersession of NOCT |
| `calculateNMOT` | `@param` / `@returns`; notes mounting correction table and wind factor |
| `calculateNOCT` | One-liner; flags as legacy, links to `calculateNMOT` |
| `calculateCellTemp` | Ross model equation in docblock; all four parameters documented |
| `calculatePerformanceAtNMOT` | Full `@param` / `@returns`; lists all output fields |
| `generateIrradianceTempModel` | Documents 2-D grid sweep; explains return shape |
| `generatePRCurve` | Documents 800 W/m² reference and PR definition |

### `lib/iv-curve.ts`

| Symbol | Documentation added |
|---|---|
| Module | Scope (single-diode model, STC/NMOT correction, IEC refs) |
| `generateIVCurve` | All five parameters + return shape |
| `calcSeriesResistance` | One-liner (slope near Voc) |
| `calcShuntResistance` | One-liner (slope near Isc) |
| `calcIdealityFactor` | One-liner |
| `correctPmaxToSTC` | Full `@param`/`@returns`; links to `correctToSTC` for full-curve use |
| `correctToSTC` | Notes the `tempCoeffPmax/Voc/Isc` field disambiguation pending PR #93 |
| `extractIVParameters` | Explains point-ordering assumption; documents zero-value fallback |
| `correctToNMOT` | Documents Ross-model cell temp derivation |

### No logic changes

This PR is documentation-only. All function bodies are unchanged; `npx tsc --noEmit` and `npm run build` are unaffected.

## Related

- Tests these functions guard: PRs #97 (87 tests) and #113 (51 tests)
- Bug the `correctToSTC` note references: PR #93 (tempCoeff alias fix, still draft)
- Ideation issues filed in parallel:
  - #114 — `@ts-nocheck` elimination plan (381 suppressions)
  - #115 — OpenAPI 3.1 spec for the 5 AI/data API routes

## Test plan

- [ ] `npx tsc --noEmit` — no new errors
- [ ] In VS Code / any TS-aware IDE, hover over `calculateCellTemp(...)` call site → parameter hints appear
- [ ] No visible change on any page (documentation only)

https://claude.ai/code/session_01RzbipvGLhndB5TFR3fMUwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzbipvGLhndB5TFR3fMUwZ)_