### PR TITLE
refactor(iv-curve): rename duplicated NMOT solver exports to remove name collision

### DIFF
--- a/components/iv-curve/NMOTCalculator.tsx
+++ b/components/iv-curve/NMOTCalculator.tsx
@@ -23,7 +23,7 @@ import {
   Bar,
 } from "recharts"
 import { Thermometer, Sun, Wind, Zap, TrendingDown, Activity } from "lucide-react"
-import { calculateNMOT, generateIrradianceTempModel, NMOTInputs } from "@/lib/iv-curve"
+import { calculateNMOTOperatingPoint, generatePowerIrradianceCurve, IVNMOTInputs } from "@/lib/iv-curve"
 
 export default function NMOTCalculator() {
   const [tAmbient, setTAmbient] = useState(25)
@@ -33,7 +33,7 @@ export default function NMOTCalculator() {
   const [tempCoeffPmax, setTempCoeffPmax] = useState(-0.35)
   const [pmaxStc, setPmaxStc] = useState(400)
 
-  const inputs: NMOTInputs = useMemo(
+  const inputs: IVNMOTInputs = useMemo(
     () => ({
       tAmbient,
       irradiance,
@@ -45,10 +45,10 @@ export default function NMOTCalculator() {
     [tAmbient, irradiance, windSpeed, nmot, tempCoeffPmax, pmaxStc]
   )
 
-  const result = useMemo(() => calculateNMOT(inputs), [inputs])
+  const result = useMemo(() => calculateNMOTOperatingPoint(inputs), [inputs])
 
   const irrTempData = useMemo(
-    () => generateIrradianceTempModel(nmot, pmaxStc, tempCoeffPmax),
+    () => generatePowerIrradianceCurve(nmot, pmaxStc, tempCoeffPmax),
     [nmot, pmaxStc, tempCoeffPmax]
   )
 

--- a/lib/iv-curve.ts
+++ b/lib/iv-curve.ts
@@ -57,7 +57,9 @@ export interface IVCurveData {
   ideality: number // diode ideality factor
 }
 
-export interface NMOTInputs {
+// Inputs for computing the operating point at a known NMOT value.
+// Distinct from nmot-noct.ts::NMOTInput, which computes the NMOT value itself.
+export interface IVNMOTInputs {
   tAmbient: number // ambient temperature °C
   irradiance: number // W/m²
   windSpeed: number // m/s
@@ -66,7 +68,7 @@ export interface NMOTInputs {
   pmax_stc: number // rated power at STC
 }
 
-export interface NMOTResult {
+export interface IVNMOTResult {
   moduleTemp: number
   pmaxAtNMOT: number
   performanceRatio: number
@@ -174,12 +176,11 @@ export function correctToSTC(curve: IVCurveData, params: TemperatureCorrectionPa
   }
 }
 
-// NMOT/NOCT calculation per IEC 61215
-export function calculateNMOT(inputs: NMOTInputs): NMOTResult {
-  // Module temperature: T_mod = T_amb + (NMOT - 20) * G / 800
-  // NMOT is measured at 800 W/m², 20°C ambient, 1 m/s wind
+// Computes module temperature and power at a given operating point for a known NMOT value.
+// Use nmot-noct.ts::calculateNMOT to derive the NMOT temperature itself.
+export function calculateNMOTOperatingPoint(inputs: IVNMOTInputs): IVNMOTResult {
   const moduleTemp = inputs.tAmbient + ((inputs.nmot - 20) * inputs.irradiance / 800)
-  const tempDelta = moduleTemp - 25 // difference from STC
+  const tempDelta = moduleTemp - 25
   const thermalLoss = Math.abs(inputs.tempCoeffPmax * tempDelta)
   const pmaxAtNMOT = inputs.pmax_stc * (1 + inputs.tempCoeffPmax / 100 * tempDelta)
   const performanceRatio = (pmaxAtNMOT / inputs.pmax_stc) * (inputs.irradiance / 1000)
@@ -193,8 +194,9 @@ export function calculateNMOT(inputs: NMOTInputs): NMOTResult {
   }
 }
 
-// Generate irradiance vs temperature model data
-export function generateIrradianceTempModel(
+// 1-D sweep of module temperature and power output vs irradiance at a fixed NMOT.
+// Use nmot-noct.ts::generateIrradianceTempModel for the 2-D cell-temp matrix.
+export function generatePowerIrradianceCurve(
   nmot: number,
   pmax_stc: number,
   tempCoeffPmax: number,


### PR DESCRIPTION
## Monday refactor — 2026-05-18

### Problem
`lib/iv-curve.ts` exported two functions with the **same names** as `lib/nmot-noct.ts` but completely different signatures and return types:

| Export | `lib/nmot-noct.ts` | `lib/iv-curve.ts` (old) |
|---|---|---|
| `calculateNMOT` | `(NMOTInput) → number` (derives the NMOT temperature) | `(NMOTInputs) → NMOTResult` (computes operating-point metrics) |
| `generateIrradianceTempModel` | `(nmot, ambientTemps[], irradiances[]) → { ambient, irradiance, cellTemp }[]` (2-D thermal matrix) | `(nmot, pmax_stc, tempCoeffPmax) → { irradiance, moduleTemp, power, pr }[]` (1-D power sweep) |
| `NMOTInputs` / `NMOTResult` | `NMOTInput`, `NMOTResult` (different shapes) | colliding names |

Any file doing `import { calculateNMOT } from "@/lib/iv-curve"` would silently get the wrong function if the import path were ever switched. TypeScript could not catch this because the names matched.

### Fix
Rename the `iv-curve.ts`-scoped exports to describe what they actually compute:

| Old name | New name |
|---|---|
| `NMOTInputs` | `IVNMOTInputs` |
| `NMOTResult` | `IVNMOTResult` |
| `calculateNMOT` | `calculateNMOTOperatingPoint` |
| `generateIrradianceTempModel` | `generatePowerIrradianceCurve` |

Updated the sole consumer (`components/iv-curve/NMOTCalculator.tsx`). No logic changed.

### Verification
- `npx tsc --noEmit` → zero errors in changed files
- `grep` confirms no remaining references to old names outside `nmot-noct.ts`

Closes part of #94.

https://claude.ai/code/session_01KaxXJsu2gP61uzsaNGvkDX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaxXJsu2gP61uzsaNGvkDX)_