### PR TITLE
chore(bulk-removal): strip debug console.log and window.alert — Tuesday 2026-05-19

### DIFF
--- a/app/(dashboard)/lims/tests/[id]/page.tsx
+++ b/app/(dashboard)/lims/tests/[id]/page.tsx
@@ -111,7 +111,7 @@ export default function TestDetailPage() {
           <TestTemplateRenderer
             template={template}
             initialData={test.inputData}
-            onSubmit={(data) => console.log('Test data submitted:', data)}
+            onSubmit={() => {}}
             readOnly={test.status === 'completed'}
           />
         </div>

--- a/components/reports/TemplateExportToolbar.tsx
+++ b/components/reports/TemplateExportToolbar.tsx
@@ -29,18 +29,13 @@ export interface TemplateExportConfig {
 /* ── Word Export ──────────────────────────────────────────────────────────────── */
 
 export async function exportToWord(config: TemplateExportConfig) {
-  window.alert('exportToWord called');
-  console.error('[DEBUG exportToWord] Function called with config:', config?.reportNo);
   try {
    try {
-    console.error('[DEBUG exportToWord] About to dynamically import docx...');
     const {
       Document, Packer, Paragraph, Table, TableRow, TableCell,
       TextRun, HeadingLevel, AlignmentType, WidthType,
       BorderStyle, ShadingType, Header, Footer, PageNumber,
     } = await import("docx");
-    console.error('[DEBUG exportToWord] docx imported successfully. ShadingType:', typeof ShadingType, ShadingType);
-
     const accent = "#0f4c81";
     const date = config.date || new Date().toISOString().slice(0, 10);
 
@@ -341,9 +336,7 @@ export async function exportToWord(config: TemplateExportConfig) {
       }],
     });
 
-    console.error('[DEBUG exportToWord] About to call Packer.toBlob...');
     const blob = await Packer.toBlob(doc);
-    console.error('[DEBUG exportToWord] Blob created, size:', blob.size);
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -352,28 +345,22 @@ export async function exportToWord(config: TemplateExportConfig) {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    console.error('[DEBUG exportToWord] Download triggered successfully');
     toast.success("Word document exported successfully");
    } catch (err: any) {
-    console.error("[DEBUG exportToWord] INNER error:", err);
     toast.error(`Word export failed: ${err?.message || "Unknown error"}`);
    }
   } catch (e: any) {
-    window.alert('ERROR: ' + e.message);
-    console.error("[DEBUG exportToWord] OUTER error:", e);
+    console.error("Word export error:", e);
+    toast.error(`Word export failed: ${e?.message || "Unknown error"}`);
   }
 }
 
 /* ── Excel Export ─────────────────────────────────────────────────────────────── */
 
 export async function exportToExcel(config: TemplateExportConfig) {
-  window.alert('exportToExcel called');
-  console.error('[DEBUG exportToExcel] Function called with config:', config?.reportNo);
   try {
    try {
-    console.error('[DEBUG exportToExcel] About to dynamically import xlsx...');
     const XLSX = await import("xlsx");
-    console.error('[DEBUG exportToExcel] xlsx imported successfully. utils:', typeof XLSX.utils);
 
     const wb = XLSX.utils.book_new();
 
@@ -434,11 +421,8 @@ export async function exportToExcel(config: TemplateExportConfig) {
       XLSX.utils.book_append_sheet(wb, ws, sheetName);
     }
 
-    console.error('[DEBUG exportToExcel] About to write workbook...');
     const wbOut = XLSX.write(wb, { bookType: "xlsx", type: "array" });
-    console.error('[DEBUG exportToExcel] Workbook written, creating blob...');
     const blob = new Blob([wbOut], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
-    console.error('[DEBUG exportToExcel] Blob created, size:', blob.size);
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -447,15 +431,13 @@ export async function exportToExcel(config: TemplateExportConfig) {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    console.error('[DEBUG exportToExcel] Download triggered successfully');
     toast.success("Excel file exported successfully");
    } catch (err: any) {
-    console.error("[DEBUG exportToExcel] INNER error:", err);
     toast.error(`Excel export failed: ${err?.message || "Unknown error"}`);
    }
   } catch (e: any) {
-    window.alert('ERROR: ' + e.message);
-    console.error("[DEBUG exportToExcel] OUTER error:", e);
+    console.error("Excel export error:", e);
+    toast.error(`Excel export failed: ${e?.message || "Unknown error"}`);
   }
 }
 


### PR DESCRIPTION
## Tuesday bulk-removal — 2026-05-19

### Problem
Two files still carried debug instrumentation that was never cleaned up before merging to main.

### Changes

**1. `app/(dashboard)/lims/tests/[id]/page.tsx` (1 line)**
- `onSubmit` on `TestTemplateRenderer` was wired to `console.log('Test data submitted:', data)`, leaking full test form payloads to the browser console in production.
- Replaced with a no-op `() => {}`. Real persistence is tracked in issue #91.
- Supersedes stale draft PR #110 (same fix, broader context).

**2. `components/reports/TemplateExportToolbar.tsx` (13 lines removed)**

`exportToWord` and `exportToExcel` both had invasive debug instrumentation:

| Removed | Count |
|---|---|
| `window.alert('exportToWord/Excel called')` on function entry | 2 |
| `console.error('[DEBUG exportToWord] …')` trace logs | 6 |
| `console.error('[DEBUG exportToExcel] …')` trace logs | 5 |

These fired **on every export in production**: the `window.alert` calls were blocking the UI with modal dialogs on every single Word or Excel download, and the `[DEBUG]` console.error logs were polluting the console at every step (import, write, blob creation, download trigger).

**Kept:** outer-catch `console.error` renamed to `"Word/Excel export error:"` (real failures should still surface), plus added `toast.error(...)` for user-visible feedback when the dynamic import itself fails.

### Net diff
```
2 files changed, 5 insertions(+), 23 deletions(-)
```

### Test plan
- [ ] Export a Word report from any template — no modal alert, no `[DEBUG]` console spam, `toast.success` fires
- [ ] Export an Excel report — same
- [ ] Submit a test template form in LIMS — no console.log in browser devtools

https://claude.ai/code/session_01KnX8nFJZLiCuihCfomwjE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnX8nFJZLiCuihCfomwjE4)_