### PR TITLE
docs(solvers): JSDoc for uncertainty.ts and sun-simulator.ts exported functions

### DIFF
--- a/lib/sun-simulator.ts
+++ b/lib/sun-simulator.ts
@@ -139,7 +139,7 @@ export function calculateSpectralMatch(data: SpectralDataPoint[]): SpectralMatch
   };
 }
 
-/** Uniformity calculation */
+/** Spatial non-uniformity result across the illuminated test plane. */
 export interface UniformityResult {
   nonUniformity: number;
   grade: ClassificationGrade;
@@ -151,6 +151,13 @@ export interface UniformityResult {
   grid: number[][];
 }
 
+/**
+ * Spatial uniformity of irradiance across the test plane per IEC 60904-9 §5.2.
+ * Non-uniformity = (Emax - Emin) / (Emax + Emin) × 100 %.
+ * A+ ≤ 1 %, A ≤ 2 %, B ≤ 5 %, C ≤ 10 %.
+ * @param grid 2-D array of irradiance measurements (W/m²) at grid positions.
+ * @returns Non-uniformity percentage, classification grade, and descriptive statistics.
+ */
 export function calculateUniformity(grid: number[][]): UniformityResult {
   const flat = grid.flat();
   const mean = flat.reduce((a, b) => a + b, 0) / flat.length;
@@ -202,6 +209,16 @@ function worseGrade(a: ClassificationGrade, b: ClassificationGrade): Classificat
   return gradeOrder.indexOf(a) >= gradeOrder.indexOf(b) ? a : b;
 }
 
+/**
+ * Temporal stability of irradiance over short (STI) and long (LTI) time intervals per IEC 60904-9 §5.3.
+ * Both indices: (Emax - Emin) / (Emax + Emin) × 100 %.
+ * STI thresholds — A+: ≤0.5 %, A: ≤2 %, B: ≤5 %, C: ≤10 %.
+ * LTI thresholds — A+: ≤1 %, A: ≤2 %, B: ≤5 %, C: ≤10 %.
+ * Overall grade is the worse of STI and LTI grades.
+ * @param stiData Short-interval irradiance time series (typically ≤10 ms window, ≥100 Hz).
+ * @param ltiData Long-interval irradiance time series (typically full flash duration).
+ * @returns STI, LTI values and grades, overall grade, and the input time series for charting.
+ */
 export function calculateTemporalStability(
   stiData: { time: number; irradiance: number }[],
   ltiData: { time: number; irradiance: number }[]
@@ -249,6 +266,14 @@ const D3: Record<number, number> = { 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0.076, 8: 
 const D4: Record<number, number> = { 2: 3.267, 3: 2.575, 4: 2.282, 5: 2.115, 6: 2.004, 7: 1.924, 8: 1.864, 9: 1.816, 10: 1.777 };
 const d2: Record<number, number> = { 2: 1.128, 3: 1.693, 4: 2.059, 5: 2.326, 6: 2.534, 7: 2.704, 8: 2.847, 9: 2.970, 10: 3.078 };
 
+/**
+ * X̄-R SPC control chart statistics and process capability indices for sun simulator QC.
+ * Uses the standard SPC constants A2, D3, D4, d2 (AIAG SPC Manual, 2nd ed.) for subgroup sizes 2–10.
+ * @param data Array of subgroups, each with a subgroup index and array of measured irradiance values.
+ * @param usl Upper specification limit (e.g. 1020 W/m² for ±2 % irradiance tolerance).
+ * @param lsl Lower specification limit (e.g. 980 W/m²).
+ * @returns X̄ and range control limits, Cp, Cpk, and per-subgroup data arrays for charting.
+ */
 export function calculateSPC(
   data: SPCDataPoint[],
   usl: number,

--- a/lib/uncertainty.ts
+++ b/lib/uncertainty.ts
@@ -63,6 +63,15 @@ export interface CorrelationEntry {
 
 // ===== Distribution Conversion =====
 
+/**
+ * Convert a raw half-width uncertainty to standard uncertainty (u) for a given distribution.
+ * Applies the divisors from JCGM 100:2008 Table B.1.
+ * @param rawUncertainty Half-width (or expanded value when isExpanded=true) in the measurement unit.
+ * @param distribution Probability distribution of the input quantity.
+ * @param isExpanded When true, rawUncertainty is treated as an expanded uncertainty U = k·u.
+ * @param k Coverage factor used when isExpanded=true (default 2, i.e. ≈95 % normal).
+ * @returns Standard uncertainty u(x).
+ */
 export function toStandardUncertainty(
   rawUncertainty: number,
   distribution: DistributionType,
@@ -89,6 +98,12 @@ export function toStandardUncertainty(
 
 // ===== Type A (Statistical) =====
 
+/**
+ * Type A uncertainty evaluation by statistical analysis of a measurement series.
+ * Computes the experimental standard deviation of the mean (JCGM 100:2008 §4.2).
+ * @param measurements Array of repeated observations of the same measurand (n ≥ 2).
+ * @returns Mean, standard deviation of the population, standard uncertainty of the mean, DOF (n-1), and count.
+ */
 export function calculateTypeA(measurements: number[]): {
   mean: number;
   stdDev: number;
@@ -107,6 +122,14 @@ export function calculateTypeA(measurements: number[]): {
 
 // ===== Combined Uncertainty (with optional correlations) =====
 
+/**
+ * Combined standard uncertainty uc(y) from a set of uncertainty components.
+ * Applies the law of propagation of uncertainty (JCGM 100:2008 §5.1) and
+ * optionally adds pairwise correlation cross-terms (§5.2.2).
+ * @param components Evaluated uncertainty components (each carries its varianceContribution = (ci·ui)²).
+ * @param correlations Optional correlation coefficients between component pairs.
+ * @returns Combined standard uncertainty uc(y) in the measurement unit.
+ */
 export function calculateCombinedUncertainty(
   components: UncertaintyComponent[],
   correlations?: CorrelationEntry[]
@@ -134,6 +157,12 @@ export function calculateCombinedUncertainty(
 
 // ===== Welch-Satterthwaite =====
 
+/**
+ * Effective degrees of freedom νeff via the Welch-Satterthwaite formula (JCGM 100:2008 §G.4.1).
+ * Used to look up the appropriate Student-t coverage factor.
+ * @param components Uncertainty components with their varianceContribution and degreesOfFreedom.
+ * @returns Effective DOF rounded to the nearest integer; Infinity when all DOF are Infinity.
+ */
 export function welchSatterthwaite(components: UncertaintyComponent[]): number {
   const totalVariance = components.reduce((sum, c) => sum + c.varianceContribution, 0);
   const uc4 = totalVariance ** 2;
@@ -148,6 +177,13 @@ export function welchSatterthwaite(components: UncertaintyComponent[]): number {
 
 // ===== Coverage Factor (Student's t) =====
 
+/**
+ * Student-t coverage factor k for a given effective DOF and coverage probability.
+ * Tabulated values from JCGM 100:2008 Table G.2; linear interpolation for non-tabulated DOF.
+ * @param dof Effective degrees of freedom (result of welchSatterthwaite); use Infinity for a normal distribution.
+ * @param probability Coverage probability (0.95 or 0.99); defaults to 0.95 (≈2σ).
+ * @returns Coverage factor k such that U = k · uc(y) covers the stated probability.
+ */
 export function getCoverageFactor(dof: number, probability: number = 0.95): number {
   if (dof === Infinity || dof > 100) {
     if (probability === 0.99) return 2.576;
@@ -182,6 +218,23 @@ export function getCoverageFactor(dof: number, probability: number = 0.95): numb
 
 // ===== Component Builder =====
 
+/**
+ * Factory function to build a fully evaluated UncertaintyComponent.
+ * Converts the raw uncertainty to standard form, computes the variance contribution,
+ * and wires the sensitivity coefficient — ready to pass to calculateBudget().
+ * @param id Unique identifier within the budget.
+ * @param name Human-readable component name (e.g. "Reference standard calibration").
+ * @param value Best estimate of the input quantity x.
+ * @param uncertainty Raw half-width (or expanded U when isExpanded=true).
+ * @param distribution Probability distribution for the input quantity.
+ * @param type "typeA" (statistical) or "typeB" (other means of evaluation).
+ * @param sensitivityCoefficient Partial derivative ∂y/∂x evaluated at best estimates.
+ * @param degreesOfFreedom Degrees of freedom for the component (default Infinity for Type B normal).
+ * @param isExpanded True when `uncertainty` is an expanded uncertainty U rather than half-width.
+ * @param category Optional fishbone category (Equipment, Method, Environment, etc.).
+ * @param description Optional free-text description.
+ * @returns Fully populated UncertaintyComponent (percentageContribution initialised to 0; set by calculateBudget).
+ */
 export function createComponent(
   id: string,
   name: string,
@@ -216,6 +269,21 @@ export function createComponent(
 
 // ===== Full Budget Calculation =====
 
+/**
+ * Compute a complete GUM-compliant uncertainty budget.
+ * Combines all components, applies Welch-Satterthwaite, looks up the coverage factor,
+ * and returns a fully populated UncertaintyBudget ready for display and PDF export.
+ * @param name Budget title (e.g. "Pmax measurement — IEC 61215 TC 200 cycle").
+ * @param measurand Symbol or description of the output quantity y.
+ * @param measuredValue Best estimate of y (used to compute relative uncertainty).
+ * @param components Evaluated uncertainty components (from createComponent).
+ * @param coverageProbability Target coverage probability (0.95 or 0.99); default 0.95.
+ * @param correlations Optional pairwise correlation entries between components.
+ * @param unit Measurement unit of y (e.g. "W", "%", "V").
+ * @param measurementModel Optional model equation string for documentation.
+ * @param standardReference Optional standard reference string (e.g. "ISO 17025:2017 §7.6").
+ * @returns UncertaintyBudget with combined uc(y), expanded U, coverage factor k, and sorted components.
+ */
 export function calculateBudget(
   name: string,
   measurand: string,
@@ -298,6 +366,18 @@ function sampleFromDistribution(
   }
 }
 
+/**
+ * Validate GUM results and characterise the output distribution via Monte Carlo simulation.
+ * Each iteration propagates independently sampled input deviations through the linear model;
+ * the 2.5/97.5 percentiles give the 95 % coverage interval without assuming normality.
+ * Note: uses the linear (sensitivity-coefficient) model. For non-linear models see planned
+ * issue #130 (JCGM 101:2008 MCM engine with functional model support).
+ * @param components Uncertainty components whose distributions to sample.
+ * @param measuredValue Best estimate of the measurand y.
+ * @param iterations Number of Monte Carlo trials (default 10 000; increase to 100 000 for publication).
+ * @param correlations Pairwise correlations — currently informational only; not yet sampled jointly.
+ * @returns Distribution statistics, histogram, and convergence trace.
+ */
 export function runMonteCarloSimulation(
   components: UncertaintyComponent[],
   measuredValue: number,


### PR DESCRIPTION
## Summary

Friday docs angle — 2026-05-22. Companion to PR #116 (which covered `lib/iv-curve.ts` and `lib/nmot-noct.ts`). Adds `@param`/`@returns` JSDoc to the two remaining undocumented solver modules.

- **`lib/uncertainty.ts`** — 8 exported functions documented: `toStandardUncertainty`, `calculateTypeA`, `calculateCombinedUncertainty`, `welchSatterthwaite`, `getCoverageFactor`, `createComponent`, `calculateBudget`, `runMonteCarloSimulation`. Each doc cites the relevant JCGM 100:2008 clause.
- **`lib/sun-simulator.ts`** — 3 functions enhanced: `calculateUniformity` (IEC 60904-9 §5.2 grade thresholds), `calculateTemporalStability` (IEC 60904-9 §5.3 STI/LTI), `calculateSPC` (AIAG constant source). Stub `/** Uniformity calculation */` on the interface expanded to a proper sentence.

No logic changes — docs only. 106 lines added, 1 replaced.

## Ideation issues filed this session

- #130 — Monte Carlo uncertainty supplement (JCGM 101:2008 GUM-S1 engine with functional model)
- #131 — IEC 61853-1 energy rating module (multi-condition power matrix → annual energy yield)

## Test plan

- [ ] Review JSDoc renders correctly in IDE tooltip (hover over each function)
- [ ] Confirm no TypeScript errors: `npx tsc --noEmit`
- [ ] Confirm no ESLint errors: `npm run lint`

https://claude.ai/code/session_011faWhfJQv3FFDMqPCDnN5E

---
_Generated by [Claude Code](https://claude.ai/code/session_011faWhfJQv3FFDMqPCDnN5E)_