### PR TITLE
security: auth guards on AI routes + credential exposure fixes

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
 
 // ---------------------------------------------------------------------------
 // POST /api/chat – RAG-powered chat endpoint
@@ -455,6 +456,9 @@ async function* streamDemo(
 // ---- Main handler ----------------------------------------------------------
 
 export async function POST(request: NextRequest) {
+  const { error: authError } = await requireAuth();
+  if (authError) return authError;
+
   try {
     const body = await request.json();
     const { message, history = [] } = body as {

--- a/app/api/reports/generate/route.ts
+++ b/app/api/reports/generate/route.ts
@@ -5,12 +5,16 @@ import {
   getStandardTitle,
   type DetailedTestResult,
 } from "@/lib/report-test-definitions";
+import { requireAuth } from "@/lib/api-auth";
 
 /**
  * POST /api/reports/generate
  * Generate an ISO 17025 compliant test report.
  */
 export async function POST(request: NextRequest) {
+  const { error: authError } = await requireAuth();
+  if (authError) return authError;
+
   try {
     const body = await request.json();
     const {

--- a/app/api/sop/generate/route.ts
+++ b/app/api/sop/generate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
 
 /**
  * POST /api/sop/generate
@@ -13,6 +14,9 @@ import { NextRequest, NextResponse } from "next/server";
  * - documentNumber: Optional SOP document number
  */
 export async function POST(request: NextRequest) {
+  const { error: authError } = await requireAuth();
+  if (authError) return authError;
+
   try {
     const body = await request.json();
     const { standard, clause, title, additionalContext, labName, documentNumber } = body;

--- a/app/api/vision/detect/route.ts
+++ b/app/api/vision/detect/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api-auth";
 
 /**
  * POST /api/vision/detect
@@ -13,6 +14,9 @@ import { NextRequest, NextResponse } from "next/server";
  * detection predictions with bounding boxes and confidence scores.
  */
 export async function POST(request: NextRequest) {
+  const { error: authError } = await requireAuth();
+  if (authError) return authError;
+
   try {
     const formData = await request.formData();
     const imageFile = formData.get("image") as File | null;
@@ -46,11 +50,15 @@ export async function POST(request: NextRequest) {
     const base64Image = Buffer.from(arrayBuffer).toString("base64");
 
     // Call Roboflow Inference API
-    const roboflowUrl = `https://detect.roboflow.com/${modelId}?api_key=${apiKey}&confidence=40&overlap=30`;
+    // api_key sent as Authorization header to avoid logging it in request URLs
+    const roboflowUrl = `https://detect.roboflow.com/${modelId}?confidence=40&overlap=30`;
 
     const roboflowResponse = await fetch(roboflowUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Authorization": `Bearer ${apiKey}`,
+      },
       body: base64Image,
     });
 

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -1,0 +1,14 @@
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+
+export async function requireAuth(): Promise<{ session: Awaited<ReturnType<typeof getServerSession>>; error: null } | { session: null; error: NextResponse }> {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return {
+      session: null,
+      error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+  return { session, error: null };
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,10 +2,11 @@
 const nextConfig = {
   images: {
     remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "**",
-      },
+      { protocol: "https", hostname: "*.vercel.app" },
+      { protocol: "https", hostname: "*.vercel.com" },
+      { protocol: "https", hostname: "storage.roboflow.com" },
+      { protocol: "https", hostname: "detect.roboflow.com" },
+      // Add additional trusted hostnames here; avoid wildcard "**" (SSRF risk)
     ],
   },
   transpilePackages: ['@react-pdf/renderer'],


### PR DESCRIPTION
## Summary

- **Unauthenticated AI endpoints** — `/api/sop/generate`, `/api/vision/detect`, `/api/reports/generate`, and `/api/chat` were callable by anyone without a session; adds `requireAuth()` guard (uses `getServerSession`) to each.
- **API key in URL** — Roboflow `api_key` was interpolated directly into the request URL (`?api_key=…`), causing it to appear in Nginx/proxy/CDN access logs; moved to `Authorization: Bearer` header.
- **Wildcard image hostname** — `next.config.mjs` had `hostname: "**"` which allows `next/image` to proxy requests to any remote origin (SSRF vector); replaced with an explicit allowlist (Vercel domains + Roboflow storage).

## Files changed

| File | Change |
|------|--------|
| `lib/api-auth.ts` | New `requireAuth()` helper wrapping `getServerSession` |
| `app/api/sop/generate/route.ts` | Add auth guard |
| `app/api/vision/detect/route.ts` | Add auth guard + move api_key to header |
| `app/api/reports/generate/route.ts` | Add auth guard |
| `app/api/chat/route.ts` | Add auth guard |
| `next.config.mjs` | Replace wildcard remotePattern with explicit hosts |

## Test plan

- [ ] Log in → call each guarded route → confirm 200
- [ ] Log out → call each guarded route directly → confirm 401
- [ ] Confirm Roboflow detection still works (Bearer header accepted)
- [ ] Confirm `next/image` still renders images from Vercel / Roboflow storage

https://claude.ai/code/session_01LX492uuFxgdqRGN3cKEBu1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX492uuFxgdqRGN3cKEBu1)_