### PR TITLE
refactor(export-utils): extract computeColWidths helper — Monday 2026-05-25

### DIFF
--- a/lib/export-utils.ts
+++ b/lib/export-utils.ts
@@ -2,6 +2,16 @@
 import * as XLSX from "xlsx"
 import { saveAs } from "file-saver"
 
+function computeColWidths(data: Record<string, unknown>[]): { wch: number }[] {
+  return Object.keys(data[0] || {}).map((key) => {
+    const maxLen = Math.max(
+      key.length,
+      ...data.map((row) => String(row[key] ?? "").length)
+    )
+    return { wch: Math.min(maxLen + 2, 40) }
+  })
+}
+
 // ─── CSV Export ──────────────────────────────────────────────────────────────
 
 export function exportToCSV(
@@ -44,14 +54,7 @@ export function exportToExcel(
   const workbook = XLSX.utils.book_new()
   XLSX.utils.book_append_sheet(workbook, worksheet, sheetName)
 
-  const colWidths = Object.keys(data[0] || {}).map((key) => {
-    const maxLen = Math.max(
-      key.length,
-      ...data.map((row) => String(row[key] ?? "").length)
-    )
-    return { wch: Math.min(maxLen + 2, 40) }
-  })
-  worksheet["!cols"] = colWidths
+  worksheet["!cols"] = computeColWidths(data)
 
   const excelBuffer = XLSX.write(workbook, { bookType: "xlsx", type: "array" })
   const blob = new Blob([excelBuffer], {
@@ -67,14 +70,7 @@ export function exportToExcelMultiSheet(
   const workbook = XLSX.utils.book_new()
   sheets.forEach(({ name, data }) => {
     const worksheet = XLSX.utils.json_to_sheet(data)
-    const colWidths = Object.keys(data[0] || {}).map((key) => {
-      const maxLen = Math.max(
-        key.length,
-        ...data.map((row) => String(row[key] ?? "").length)
-      )
-      return { wch: Math.min(maxLen + 2, 40) }
-    })
-    worksheet["!cols"] = colWidths
+    worksheet["!cols"] = computeColWidths(data)
     XLSX.utils.book_append_sheet(workbook, worksheet, name)
   })
 


### PR DESCRIPTION
## Summary

- Extract private `computeColWidths(data)` helper in `lib/export-utils.ts`
- Eliminate the 8-line duplicated column-width block that existed identically in both `exportToExcel` and `exportToExcelMultiSheet`
- Replace both call sites with `worksheet["!cols"] = computeColWidths(data)`

## What changed

| Before | After |
|--------|-------|
| 8-line `colWidths` block copied in `exportToExcel` | Single `computeColWidths` helper |
| 8-line `colWidths` block copied in `exportToExcelMultiSheet` | Both callers use the helper |

No behaviour change — identical arithmetic and 40-char cap preserved.

## Why

The two copies were one edit away from diverging silently if column-sizing logic is ever adjusted (different cap, locale-aware header lengths, etc.). The helper also gives the forthcoming `xlsx` CVE replacement (issue #136) a single seam to update when the sheet-building API changes.

## Related

- Issue #136 — xlsx CVE replacement (when xlsx is swapped, `computeColWidths` is the only touch-point for column sizing)
- Issue #114 — @ts-nocheck elimination plan (this file still carries `// @ts-nocheck` at line 1; tracked separately)

https://claude.ai/code/session_014ZaUV2jgxohoVeAanaueDW

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZaUV2jgxohoVeAanaueDW)_