### PR TITLE
test(solvers): bootstrap Vitest — 91 unit tests for GUM uncertainty, IV-curve, IEC 60904-9 classifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,13 +63,15 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
         "eslint-config-next": "14.2.18",
         "postcss": "^8.4.49",
         "prisma": "^5.22.0",
         "tailwindcss": "^3.4.15",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -82,6 +84,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -114,6 +130,42 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
@@ -121,6 +173,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -155,6 +231,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -341,6 +859,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2236,6 +2764,356 @@
         "@react-pdf/stylesheet": "^6.1.2"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2282,6 +3160,17 @@
       "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -2344,6 +3233,20 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/file-saver": {
@@ -3010,6 +3913,155 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3329,10 +4381,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3587,6 +4668,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3708,6 +4799,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3723,6 +4831,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -4166,6 +5284,16 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4481,6 +5609,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4537,6 +5672,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -5006,6 +6183,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5038,6 +6225,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5691,6 +6888,13 @@
       "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -6266,6 +7470,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6565,6 +7823,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -6584,6 +7849,44 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7223,6 +8526,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7313,6 +8623,23 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -8056,6 +9383,58 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8336,6 +9715,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8396,6 +9782,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -8405,6 +9798,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8670,6 +10070,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -8812,6 +10232,131 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -8861,6 +10406,20 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8904,6 +10463,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9309,6 +10898,81 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-compatible-readable-stream": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
@@ -9321,6 +10985,146 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -9451,6 +11255,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
@@ -64,12 +67,14 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/uuid": "^10.0.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.18",
     "postcss": "^8.4.49",
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.15",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/tests/unit/iv-curve.test.ts
+++ b/tests/unit/iv-curve.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import {
+  correctPmaxToSTC,
+  calculateNMOT,
+  generateIrradianceTempModel,
+  extractIVParameters,
+  DEFAULT_TEMP_COEFFICIENTS,
+} from '../../lib/iv-curve'
+import type { IVDataPoint } from '../../lib/iv-curve'
+
+// ─── DEFAULT_TEMP_COEFFICIENTS (regression guard) ────────────────────────────
+
+describe('DEFAULT_TEMP_COEFFICIENTS', () => {
+  it('tempCoeffPmax = -0.35 %/°C (IEC 60904-1 typical)', () => {
+    expect(DEFAULT_TEMP_COEFFICIENTS.tempCoeffPmax).toBe(-0.35)
+  })
+  it('tempCoeffVoc = -0.30 %/°C', () => {
+    expect(DEFAULT_TEMP_COEFFICIENTS.tempCoeffVoc).toBe(-0.30)
+  })
+  it('tempCoeffIsc = +0.05 %/°C', () => {
+    expect(DEFAULT_TEMP_COEFFICIENTS.tempCoeffIsc).toBe(0.05)
+  })
+  it('aliases gammaPmax/betaVoc/alphaIsc match primary coefficients', () => {
+    expect(DEFAULT_TEMP_COEFFICIENTS.gammaPmax).toBe(DEFAULT_TEMP_COEFFICIENTS.tempCoeffPmax)
+    expect(DEFAULT_TEMP_COEFFICIENTS.betaVoc).toBe(DEFAULT_TEMP_COEFFICIENTS.tempCoeffVoc)
+    expect(DEFAULT_TEMP_COEFFICIENTS.alphaIsc).toBe(DEFAULT_TEMP_COEFFICIENTS.tempCoeffIsc)
+  })
+  it('nmot and noct default to 45 °C', () => {
+    expect(DEFAULT_TEMP_COEFFICIENTS.nmot).toBe(45)
+    expect(DEFAULT_TEMP_COEFFICIENTS.noct).toBe(45)
+  })
+})
+
+// ─── correctPmaxToSTC ────────────────────────────────────────────────────────
+
+describe('correctPmaxToSTC', () => {
+  it('at STC (G=1000, T=25) returns pmax unchanged', () => {
+    expect(correctPmaxToSTC(300, 1000, 25, -0.35)).toBeCloseTo(300, 2)
+  })
+  it('G=800, T=25: irradiance correction 1000/800 = 1.25', () => {
+    expect(correctPmaxToSTC(250, 800, 25, -0.35)).toBeCloseTo(312.5, 2)
+  })
+  it('G=1000, T=45: negative tempCoeff boosts corrected power (colder at STC)', () => {
+    // tempCorrection = 1 + (-0.35/100) × (25 - 45) = 1 + 0.07 = 1.07
+    expect(correctPmaxToSTC(250, 1000, 45, -0.35)).toBeCloseTo(250 * 1.07, 2)
+  })
+  it('G=1000, T=10: positive delta reduces corrected power (warmer at STC)', () => {
+    // tempCorrection = 1 + (-0.35/100) × (25 - 10) = 1 - 0.0525 = 0.9475
+    expect(correctPmaxToSTC(300, 1000, 10, -0.35)).toBeCloseTo(300 * 0.9475, 2)
+  })
+  it('combined G=800, T=35: both corrections applied', () => {
+    // irr: 1000/800 = 1.25; temp: 1 + (-0.35/100) × (25-35) = 1.035
+    const expected = parseFloat((250 * 1.25 * 1.035).toFixed(2))
+    expect(correctPmaxToSTC(250, 800, 35, -0.35)).toBe(expected)
+  })
+  it('zero irradiance or zero pmax returns 0', () => {
+    expect(correctPmaxToSTC(0, 1000, 25, -0.35)).toBe(0)
+  })
+})
+
+// ─── calculateNMOT ───────────────────────────────────────────────────────────
+
+describe('calculateNMOT', () => {
+  it('at NMOT reference (T_amb=20, G=800) module temp = nmot', () => {
+    // T_mod = 20 + (45 - 20) × 800/800 = 45
+    const r = calculateNMOT({ tAmbient: 20, irradiance: 800, windSpeed: 1, nmot: 45, tempCoeffPmax: -0.35, pmax_stc: 400 })
+    expect(r.moduleTemp).toBeCloseTo(45, 1)
+  })
+  it('Ross model: T_mod = T_amb + (nmot - 20) × G / 800', () => {
+    const nmot = 46
+    const G = 1000
+    const tAmb = 25
+    const expected = tAmb + (nmot - 20) * G / 800
+    const r = calculateNMOT({ tAmbient: tAmb, irradiance: G, windSpeed: 1, nmot, tempCoeffPmax: -0.35, pmax_stc: 400 })
+    expect(r.moduleTemp).toBeCloseTo(expected, 1)
+  })
+  it('pmaxAtNMOT = pmax_stc × (1 + tc/100 × (T_mod − 25))', () => {
+    const pmax_stc = 400
+    const tc = -0.35
+    const r = calculateNMOT({ tAmbient: 20, irradiance: 800, windSpeed: 1, nmot: 45, tempCoeffPmax: tc, pmax_stc })
+    // T_mod = 45 → tempDelta = 20
+    const expected = pmax_stc * (1 + tc / 100 * 20)
+    expect(r.pmaxAtNMOT).toBeCloseTo(expected, 1)
+  })
+  it('thermalLoss = |tempCoeffPmax × tempDelta| (percent)', () => {
+    const r = calculateNMOT({ tAmbient: 20, irradiance: 800, windSpeed: 1, nmot: 45, tempCoeffPmax: -0.35, pmax_stc: 400 })
+    // tempDelta = 45 − 25 = 20; loss = |-0.35 × 20| = 7.0%
+    expect(r.thermalLoss).toBeCloseTo(7.0, 1)
+  })
+  it('tempDelta = moduleTemp − 25', () => {
+    const r = calculateNMOT({ tAmbient: 20, irradiance: 800, windSpeed: 1, nmot: 45, tempCoeffPmax: -0.35, pmax_stc: 400 })
+    expect(r.tempDelta).toBeCloseTo(r.moduleTemp - 25, 1)
+  })
+  it('higher irradiance increases module temperature', () => {
+    const base = { tAmbient: 20, windSpeed: 1, nmot: 45, tempCoeffPmax: -0.35, pmax_stc: 400 }
+    const low = calculateNMOT({ ...base, irradiance: 400 })
+    const high = calculateNMOT({ ...base, irradiance: 1000 })
+    expect(high.moduleTemp).toBeGreaterThan(low.moduleTemp)
+  })
+})
+
+// ─── generateIrradianceTempModel ─────────────────────────────────────────────
+
+describe('generateIrradianceTempModel', () => {
+  it('generates 11 points: G = 200 to 1200 in 100 W/m² steps', () => {
+    const data = generateIrradianceTempModel(45, 400, -0.35)
+    expect(data).toHaveLength(11)
+    expect(data[0].irradiance).toBe(200)
+    expect(data[10].irradiance).toBe(1200)
+  })
+  it('irradiance increments are exactly 100 W/m²', () => {
+    const data = generateIrradianceTempModel(45, 400, -0.35)
+    for (let i = 1; i < data.length; i++) {
+      expect(data[i].irradiance - data[i - 1].irradiance).toBe(100)
+    }
+  })
+  it('module temperature increases with irradiance (Ross model)', () => {
+    const data = generateIrradianceTempModel(45, 400, -0.35)
+    for (let i = 1; i < data.length; i++) {
+      expect(data[i].moduleTemp).toBeGreaterThan(data[i - 1].moduleTemp)
+    }
+  })
+  it('pr is defined as power / (pmax_stc × G/1000)', () => {
+    const pmax_stc = 400
+    const data = generateIrradianceTempModel(45, pmax_stc, -0.35)
+    for (const d of data) {
+      const expected = d.power / (pmax_stc * d.irradiance / 1000)
+      expect(d.pr).toBeCloseTo(expected, 3)
+    }
+  })
+  it('power at G=1000 equals pmaxAtNMOT from calculateNMOT with same params', () => {
+    const data = generateIrradianceTempModel(45, 400, -0.35)
+    const pt1000 = data.find(d => d.irradiance === 1000)!
+    const nmotResult = calculateNMOT({ tAmbient: 25, irradiance: 1000, windSpeed: 1, nmot: 45, tempCoeffPmax: -0.35, pmax_stc: 400 })
+    expect(pt1000.power).toBeCloseTo(nmotResult.pmaxAtNMOT, 1)
+  })
+})
+
+// ─── extractIVParameters ─────────────────────────────────────────────────────
+
+describe('extractIVParameters', () => {
+  it('empty array returns all-zero result', () => {
+    const r = extractIVParameters([])
+    expect(r.voc).toBe(0)
+    expect(r.isc).toBe(0)
+    expect(r.pmax).toBe(0)
+    expect(r.ff).toBe(0)
+  })
+  it('Isc is taken from the first point (V=0)', () => {
+    const points: IVDataPoint[] = [
+      { voltage: 0, current: 9.5, power: 0 },
+      { voltage: 20, current: 9.0, power: 180 },
+      { voltage: 40, current: 0, power: 0 },
+    ]
+    expect(extractIVParameters(points).isc).toBe(9.5)
+  })
+  it('Voc is taken from the last point', () => {
+    const points: IVDataPoint[] = [
+      { voltage: 0, current: 9.5, power: 0 },
+      { voltage: 20, current: 9.0, power: 180 },
+      { voltage: 40, current: 0, power: 0 },
+    ]
+    expect(extractIVParameters(points).voc).toBe(40)
+  })
+  it('Pmax and fill factor are extracted correctly', () => {
+    const points: IVDataPoint[] = [
+      { voltage: 0, current: 10, power: 0 },
+      { voltage: 30, current: 9, power: 270 },   // MPP
+      { voltage: 40, current: 0, power: 0 },
+    ]
+    const r = extractIVParameters(points)
+    expect(r.pmax).toBe(270)
+    expect(r.vmpp).toBe(30)
+    expect(r.impp).toBe(9)
+    // FF = 270 / (40 × 10) = 0.675
+    expect(r.ff).toBeCloseTo(0.675, 3)
+  })
+  it('FF is in range (0, 1] for a valid IV curve', () => {
+    const points: IVDataPoint[] = [
+      { voltage: 0, current: 9.5, power: 0 },
+      { voltage: 35, current: 8.8, power: 308 },
+      { voltage: 45, current: 0, power: 0 },
+    ]
+    const r = extractIVParameters(points)
+    expect(r.ff).toBeGreaterThan(0)
+    expect(r.ff).toBeLessThanOrEqual(1)
+  })
+})

--- a/tests/unit/sun-simulator.test.ts
+++ b/tests/unit/sun-simulator.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateUniformity,
+  calculateTemporalStability,
+  overallClassification,
+  calculateSpectralMatch,
+  WAVELENGTH_BANDS,
+} from '../../lib/sun-simulator'
+import type { ClassificationGrade, SpectralDataPoint } from '../../lib/sun-simulator'
+
+// ─── calculateUniformity ─────────────────────────────────────────────────────
+
+describe('calculateUniformity', () => {
+  it('uniform grid: nonUniformity=0, grade=A+', () => {
+    const r = calculateUniformity([[1000, 1000], [1000, 1000]])
+    expect(r.nonUniformity).toBe(0)
+    expect(r.grade).toBe('A+')
+    expect(r.mean).toBe(1000)
+  })
+  it('IEC 60904-9 formula: (max−min)/(max+min)×100', () => {
+    // max=1020, min=980 → 40/2000×100 = 2.0% → grade A
+    const r = calculateUniformity([[980, 1020], [1000, 1000]])
+    expect(r.nonUniformity).toBeCloseTo(2.0, 6)
+    expect(r.grade).toBe('A')
+  })
+  it('grade boundary ≤1%: A+', () => {
+    // max=1010, min=990 → 20/2000×100 = 1.0% → A+
+    expect(calculateUniformity([[990, 1010]]).grade).toBe('A+')
+  })
+  it('grade boundary >1%, ≤2%: A', () => {
+    // exactly 2.0% (see above)
+    expect(calculateUniformity([[980, 1020]]).grade).toBe('A')
+  })
+  it('grade boundary >2%, ≤5%: B', () => {
+    // max=1030, min=970 → 60/2000×100 = 3.0%
+    expect(calculateUniformity([[970, 1030]]).grade).toBe('B')
+  })
+  it('grade boundary >5%, ≤10%: C', () => {
+    // max=1100, min=900 → 200/2000×100 = 10.0%
+    expect(calculateUniformity([[900, 1100]]).grade).toBe('C')
+  })
+  it('grade boundary >10%: Fail', () => {
+    // max=1200, min=800 → 400/2000×100 = 20%
+    expect(calculateUniformity([[800, 1200]]).grade).toBe('Fail')
+  })
+  it('returns correct min, max, and mean over the full grid', () => {
+    const r = calculateUniformity([[900, 1100], [950, 1050]])
+    expect(r.min).toBe(900)
+    expect(r.max).toBe(1100)
+    expect(r.mean).toBe(1000)
+    expect(r.grid).toBeDefined()
+  })
+  it('std and cv are non-negative', () => {
+    const r = calculateUniformity([[970, 1030], [990, 1010]])
+    expect(r.std).toBeGreaterThanOrEqual(0)
+    expect(r.cv).toBeGreaterThanOrEqual(0)
+  })
+})
+
+// ─── calculateTemporalStability ───────────────────────────────────────────────
+
+describe('calculateTemporalStability', () => {
+  const ltiConstant = [{ time: 0, irradiance: 1000 }, { time: 3600, irradiance: 1000 }]
+
+  it('constant irradiance: sti=0, lti=0, overallGrade=A+', () => {
+    const stiData = [{ time: 0, irradiance: 1000 }, { time: 10, irradiance: 1000 }]
+    const r = calculateTemporalStability(stiData, ltiConstant)
+    expect(r.sti).toBe(0)
+    expect(r.lti).toBe(0)
+    expect(r.stiGrade).toBe('A+')
+    expect(r.ltiGrade).toBe('A+')
+    expect(r.overallGrade).toBe('A+')
+  })
+  it('STI formula: (max−min)/(max+min)×100', () => {
+    // max=1010, min=990 → 1.0%
+    const stiData = [{ time: 0, irradiance: 990 }, { time: 5, irradiance: 1010 }]
+    const r = calculateTemporalStability(stiData, ltiConstant)
+    expect(r.sti).toBeCloseTo(1.0, 6)
+  })
+  it('STI thresholds: ≤0.5→A+, ≤2→A, ≤5→B, ≤10→C', () => {
+    // A+: max=1003, min=997 → 0.3%
+    expect(calculateTemporalStability(
+      [{ time: 0, irradiance: 997 }, { time: 5, irradiance: 1003 }], ltiConstant
+    ).stiGrade).toBe('A+')
+    // A: max=1010, min=990 → 1.0%
+    expect(calculateTemporalStability(
+      [{ time: 0, irradiance: 990 }, { time: 5, irradiance: 1010 }], ltiConstant
+    ).stiGrade).toBe('A')
+    // B: max=1030, min=970 → 3.0%
+    expect(calculateTemporalStability(
+      [{ time: 0, irradiance: 970 }, { time: 5, irradiance: 1030 }], ltiConstant
+    ).stiGrade).toBe('B')
+    // C: max=1060, min=940 → 6.0%
+    expect(calculateTemporalStability(
+      [{ time: 0, irradiance: 940 }, { time: 5, irradiance: 1060 }], ltiConstant
+    ).stiGrade).toBe('C')
+  })
+  it('LTI threshold ≤1→A+, >1≤2→A', () => {
+    // A+: max=1005, min=995 → 0.5%
+    expect(calculateTemporalStability(ltiConstant,
+      [{ time: 0, irradiance: 995 }, { time: 3600, irradiance: 1005 }]
+    ).ltiGrade).toBe('A+')
+    // A: max=1015, min=985 → 1.5% (strictly >1, ≤2)
+    expect(calculateTemporalStability(ltiConstant,
+      [{ time: 0, irradiance: 985 }, { time: 3600, irradiance: 1015 }]
+    ).ltiGrade).toBe('A')
+  })
+  it('overallGrade is the worst of stiGrade and ltiGrade', () => {
+    // STI=A+, LTI=B
+    const r = calculateTemporalStability(
+      ltiConstant,
+      [{ time: 0, irradiance: 970 }, { time: 3600, irradiance: 1030 }] // lti=3% → B
+    )
+    expect(r.ltiGrade).toBe('B')
+    expect(r.overallGrade).toBe('B')
+  })
+  it('result contains the input data arrays', () => {
+    const stiData = [{ time: 0, irradiance: 1000 }]
+    const ltiData = [{ time: 0, irradiance: 1000 }]
+    const r = calculateTemporalStability(stiData, ltiData)
+    expect(r.stiData).toBe(stiData)
+    expect(r.ltiData).toBe(ltiData)
+  })
+})
+
+// ─── overallClassification ────────────────────────────────────────────────────
+
+describe('overallClassification', () => {
+  it('all A+ → A+', () => {
+    expect(overallClassification('A+', 'A+', 'A+')).toBe('A+')
+  })
+  it('one A among A+ grades → A', () => {
+    expect(overallClassification('A+', 'A', 'A+')).toBe('A')
+    expect(overallClassification('A', 'A+', 'A+')).toBe('A')
+    expect(overallClassification('A+', 'A+', 'A')).toBe('A')
+  })
+  it('one B among better grades → B', () => {
+    expect(overallClassification('B', 'A+', 'A')).toBe('B')
+    expect(overallClassification('A+', 'B', 'A+')).toBe('B')
+  })
+  it('one C → C regardless of other grades', () => {
+    expect(overallClassification('C', 'A+', 'A')).toBe('C')
+    expect(overallClassification('A+', 'C', 'B')).toBe('C')
+  })
+  it('any Fail → Fail', () => {
+    expect(overallClassification('Fail', 'A+', 'A+')).toBe('Fail')
+    expect(overallClassification('A+', 'Fail', 'A+')).toBe('Fail')
+    expect(overallClassification('A', 'B', 'Fail')).toBe('Fail')
+  })
+  it('grade ordering A+ < A < B < C < Fail is strictly enforced', () => {
+    const grades: ClassificationGrade[] = ['A+', 'A', 'B', 'C', 'Fail']
+    // overallClassification(grades[i], grades[j], 'A+') should always be grades[i] when i >= j
+    for (let i = 0; i < grades.length; i++) {
+      for (let j = 0; j <= i; j++) {
+        expect(overallClassification(grades[i], grades[j], 'A+')).toBe(grades[i])
+      }
+    }
+  })
+})
+
+// ─── calculateSpectralMatch ───────────────────────────────────────────────────
+
+describe('calculateSpectralMatch', () => {
+  function flatSpectrum(start = 400, end = 1100, step = 10, value = 1.0): SpectralDataPoint[] {
+    const pts: SpectralDataPoint[] = []
+    for (let wl = start; wl <= end; wl += step) pts.push({ wavelength: wl, irradiance: value })
+    return pts
+  }
+
+  it('returns one SpectralBandResult per WAVELENGTH_BANDS entry (6 bands)', () => {
+    const r = calculateSpectralMatch(flatSpectrum())
+    expect(r.intervals).toHaveLength(WAVELENGTH_BANDS.length)
+    expect(r.intervals).toHaveLength(6)
+  })
+  it('all band ratios are positive', () => {
+    const r = calculateSpectralMatch(flatSpectrum())
+    for (const band of r.intervals) {
+      expect(band.ratio).toBeGreaterThan(0)
+    }
+  })
+  it('minRatio ≤ meanRatio ≤ maxRatio', () => {
+    const r = calculateSpectralMatch(flatSpectrum())
+    expect(r.minRatio).toBeLessThanOrEqual(r.meanRatio)
+    expect(r.meanRatio).toBeLessThanOrEqual(r.maxRatio)
+  })
+  it('grade is a valid ClassificationGrade string', () => {
+    const r = calculateSpectralMatch(flatSpectrum())
+    expect(['A+', 'A', 'B', 'C', 'Fail']).toContain(r.grade)
+  })
+  it('band result contains all required fields', () => {
+    const r = calculateSpectralMatch(flatSpectrum())
+    for (const b of r.intervals) {
+      expect(b).toHaveProperty('band')
+      expect(b).toHaveProperty('ratio')
+      expect(b).toHaveProperty('measuredFraction')
+      expect(b).toHaveProperty('referenceFraction')
+      expect(typeof b.inSpecAPlus).toBe('boolean')
+      expect(typeof b.inSpecA).toBe('boolean')
+    }
+  })
+  it('inSpecA implies inSpecB implies inSpecC (containment)', () => {
+    const r = calculateSpectralMatch(flatSpectrum())
+    for (const b of r.intervals) {
+      if (b.inSpecAPlus) expect(b.inSpecA).toBe(true)
+      if (b.inSpecA) expect(b.inSpecB).toBe(true)
+      if (b.inSpecB) expect(b.inSpecC).toBe(true)
+    }
+  })
+  it('does not throw on a single-wavelength input', () => {
+    expect(() => calculateSpectralMatch([{ wavelength: 550, irradiance: 1.0 }])).not.toThrow()
+  })
+  it('very high irradiance in one band is handled without NaN', () => {
+    const data: SpectralDataPoint[] = flatSpectrum()
+    // spike at 550 nm
+    const idx = data.findIndex(p => p.wavelength === 550)
+    data[idx] = { wavelength: 550, irradiance: 1000 }
+    const r = calculateSpectralMatch(data)
+    for (const b of r.intervals) {
+      expect(Number.isFinite(b.ratio)).toBe(true)
+      expect(Number.isNaN(b.ratio)).toBe(false)
+    }
+  })
+})

--- a/tests/unit/uncertainty.test.ts
+++ b/tests/unit/uncertainty.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toStandardUncertainty,
+  calculateTypeA,
+  calculateCombinedUncertainty,
+  welchSatterthwaite,
+  getCoverageFactor,
+  createComponent,
+  calculateBudget,
+} from '../../lib/uncertainty'
+
+const SQRT2 = Math.sqrt(2)
+const SQRT3 = Math.sqrt(3)
+const SQRT6 = Math.sqrt(6)
+
+// ─── toStandardUncertainty ────────────────────────────────────────────────────
+
+describe('toStandardUncertainty', () => {
+  it('normal distribution passes through unchanged', () => {
+    expect(toStandardUncertainty(2.0, 'normal')).toBeCloseTo(2.0, 10)
+  })
+  it('lognormal distribution passes through unchanged', () => {
+    expect(toStandardUncertainty(3.5, 'lognormal')).toBeCloseTo(3.5, 10)
+  })
+  it('uniform: divides by sqrt(3) — JCGM 100:2008 Table B.1', () => {
+    expect(toStandardUncertainty(1.0, 'uniform')).toBeCloseTo(1 / SQRT3, 10)
+  })
+  it('triangular: divides by sqrt(6)', () => {
+    expect(toStandardUncertainty(1.0, 'triangular')).toBeCloseTo(1 / SQRT6, 10)
+  })
+  it('u-shaped: divides by sqrt(2)', () => {
+    expect(toStandardUncertainty(1.0, 'u-shaped')).toBeCloseTo(1 / SQRT2, 10)
+  })
+  it('expanded=true k=2 with uniform: halves first, then divides by sqrt(3)', () => {
+    // U=2, k=2 → half-width = 1.0 → /sqrt(3)
+    expect(toStandardUncertainty(2.0, 'uniform', true, 2)).toBeCloseTo(1 / SQRT3, 10)
+  })
+  it('expanded=true k=1.96 with normal: divides by k only', () => {
+    expect(toStandardUncertainty(1.96, 'normal', true, 1.96)).toBeCloseTo(1.0, 10)
+  })
+  it('zero input returns zero for every distribution', () => {
+    for (const dist of ['normal', 'uniform', 'triangular', 'u-shaped', 'lognormal'] as const) {
+      expect(toStandardUncertainty(0, dist)).toBe(0)
+    }
+  })
+})
+
+// ─── calculateTypeA ───────────────────────────────────────────────────────────
+
+describe('calculateTypeA', () => {
+  it('[3,5,7,9,11]: mean=7, stdDev=√10, u_A=√2, dof=4', () => {
+    // variance = [(3-7)²+(5-7)²+0+(9-7)²+(11-7)²] / (5-1) = 40/4 = 10
+    const r = calculateTypeA([3, 5, 7, 9, 11])
+    expect(r.mean).toBeCloseTo(7, 10)
+    expect(r.stdDev).toBeCloseTo(Math.sqrt(10), 8)
+    expect(r.standardUncertainty).toBeCloseTo(Math.sqrt(2), 8) // √10/√5
+    expect(r.degreesOfFreedom).toBe(4)
+    expect(r.n).toBe(5)
+  })
+  it('n=1 returns zero uncertainty and zero dof', () => {
+    const r = calculateTypeA([42])
+    expect(r.mean).toBe(42)
+    expect(r.standardUncertainty).toBe(0)
+    expect(r.degreesOfFreedom).toBe(0)
+  })
+  it('identical measurements give zero stdDev and zero standardUncertainty', () => {
+    const r = calculateTypeA([5, 5, 5, 5])
+    expect(r.stdDev).toBe(0)
+    expect(r.standardUncertainty).toBe(0)
+    expect(r.mean).toBe(5)
+  })
+  it('degreesOfFreedom = n - 1 (Bessel correction)', () => {
+    for (const n of [2, 3, 5, 10, 20]) {
+      const arr = Array.from({ length: n }, (_, i) => i)
+      expect(calculateTypeA(arr).degreesOfFreedom).toBe(n - 1)
+    }
+  })
+})
+
+// ─── getCoverageFactor ────────────────────────────────────────────────────────
+
+describe('getCoverageFactor', () => {
+  it('returns tabulated t₉₅ values for exact dof entries', () => {
+    expect(getCoverageFactor(2, 0.95)).toBeCloseTo(4.303, 3)
+    expect(getCoverageFactor(5, 0.95)).toBeCloseTo(2.571, 3)
+    expect(getCoverageFactor(10, 0.95)).toBeCloseTo(2.228, 3)
+    expect(getCoverageFactor(20, 0.95)).toBeCloseTo(2.086, 3)
+  })
+  it('returns tabulated t₉₉ values for exact dof entries', () => {
+    expect(getCoverageFactor(5, 0.99)).toBeCloseTo(4.032, 3)
+    expect(getCoverageFactor(10, 0.99)).toBeCloseTo(3.169, 3)
+    expect(getCoverageFactor(20, 0.99)).toBeCloseTo(2.845, 3)
+  })
+  it('returns 1.96 for infinite dof at 95%', () => {
+    expect(getCoverageFactor(Infinity, 0.95)).toBeCloseTo(1.96, 3)
+    expect(getCoverageFactor(200, 0.95)).toBeCloseTo(1.96, 1)
+  })
+  it('returns 2.576 for infinite dof at 99%', () => {
+    expect(getCoverageFactor(Infinity, 0.99)).toBeCloseTo(2.576, 3)
+  })
+  it('interpolates monotonically between tabulated rows', () => {
+    const k10 = getCoverageFactor(10, 0.95)
+    const k15 = getCoverageFactor(15, 0.95) // tabulated
+    const k12 = getCoverageFactor(12, 0.95) // interpolated
+    expect(k12).toBeGreaterThan(k15)
+    expect(k12).toBeLessThan(k10)
+  })
+  it('k decreases monotonically with dof at 95%', () => {
+    const dofs = [1, 2, 5, 10, 20, 50, 100]
+    const ks = dofs.map(d => getCoverageFactor(d, 0.95))
+    for (let i = 1; i < ks.length; i++) {
+      expect(ks[i]).toBeLessThan(ks[i - 1])
+    }
+  })
+})
+
+// ─── createComponent ─────────────────────────────────────────────────────────
+
+describe('createComponent', () => {
+  it('standardUncertainty = toStandardUncertainty(uncertainty, distribution)', () => {
+    const c = createComponent('u1', 'cal cert', 100, 2, 'uniform', 'typeB', 1, Infinity)
+    expect(c.standardUncertainty).toBeCloseTo(2 / SQRT3, 8)
+  })
+  it('varianceContribution = (ci × standardUncertainty)²', () => {
+    const ci = 1.5
+    const c = createComponent('u2', 'temp sensor', 25, 0.4, 'normal', 'typeB', ci, 30)
+    expect(c.varianceContribution).toBeCloseTo((ci * 0.4) ** 2, 10)
+  })
+  it('percentageContribution is initialised to 0 — set by calculateBudget', () => {
+    const c = createComponent('u3', 'ref std', 0, 1, 'normal', 'typeB', 1, Infinity)
+    expect(c.percentageContribution).toBe(0)
+  })
+  it('all required UncertaintyComponent fields are present', () => {
+    const c = createComponent('u4', 'irradiance', 1000, 5, 'uniform', 'typeB', 1, Infinity, false, 'Equipment')
+    expect(c).toHaveProperty('id', 'u4')
+    expect(c).toHaveProperty('name', 'irradiance')
+    expect(c).toHaveProperty('standardUncertainty')
+    expect(c).toHaveProperty('varianceContribution')
+    expect(c).toHaveProperty('distribution', 'uniform')
+    expect(c).toHaveProperty('category', 'Equipment')
+  })
+})
+
+// ─── calculateCombinedUncertainty ────────────────────────────────────────────
+
+describe('calculateCombinedUncertainty', () => {
+  it('3²+4²=5²: two uncorrelated normal components give 5', () => {
+    const c1 = createComponent('a', 'u1', 0, 3, 'normal', 'typeB', 1, Infinity)
+    const c2 = createComponent('b', 'u2', 0, 4, 'normal', 'typeB', 1, Infinity)
+    expect(calculateCombinedUncertainty([c1, c2])).toBeCloseTo(5, 8)
+  })
+  it('single component: result = |ci| × standardUncertainty', () => {
+    const c = createComponent('x', 'single', 0, 2, 'normal', 'typeA', 3, 10)
+    expect(calculateCombinedUncertainty([c])).toBeCloseTo(6, 8)
+  })
+  it('positive correlation increases combined uncertainty', () => {
+    const c1 = createComponent('a', 'u1', 0, 1, 'normal', 'typeB', 1, Infinity)
+    const c2 = createComponent('b', 'u2', 0, 1, 'normal', 'typeB', 1, Infinity)
+    const noCorr = calculateCombinedUncertainty([c1, c2])
+    const withCorr = calculateCombinedUncertainty(
+      [c1, c2],
+      [{ component1Id: 'a', component2Id: 'b', coefficient: 0.8 }]
+    )
+    expect(withCorr).toBeGreaterThan(noCorr)
+  })
+  it('negative correlation decreases combined uncertainty', () => {
+    const c1 = createComponent('a', 'u1', 0, 1, 'normal', 'typeB', 1, Infinity)
+    const c2 = createComponent('b', 'u2', 0, 1, 'normal', 'typeB', 1, Infinity)
+    const noCorr = calculateCombinedUncertainty([c1, c2])
+    const withCorr = calculateCombinedUncertainty(
+      [c1, c2],
+      [{ component1Id: 'a', component2Id: 'b', coefficient: -0.8 }]
+    )
+    expect(withCorr).toBeLessThan(noCorr)
+  })
+  it('full negative correlation on equal components gives zero', () => {
+    const c1 = createComponent('a', 'u1', 0, 1, 'normal', 'typeB', 1, Infinity)
+    const c2 = createComponent('b', 'u2', 0, 1, 'normal', 'typeB', 1, Infinity)
+    const result = calculateCombinedUncertainty(
+      [c1, c2],
+      [{ component1Id: 'a', component2Id: 'b', coefficient: -1 }]
+    )
+    expect(result).toBeCloseTo(0, 8)
+  })
+})
+
+// ─── welchSatterthwaite ───────────────────────────────────────────────────────
+
+describe('welchSatterthwaite', () => {
+  it('4 equal-variance equal-dof(10) components → ν_eff = 40', () => {
+    // uc4 = 4² = 16; denom = 4 × (1²/10) = 0.4; ν = round(16/0.4) = 40
+    const comps = [1, 2, 3, 4].map(i =>
+      createComponent(`c${i}`, `u${i}`, 0, 1, 'normal', 'typeB', 1, 10)
+    )
+    expect(welchSatterthwaite(comps)).toBe(40)
+  })
+  it('infinite dof component does not contribute to denominator', () => {
+    // finite: var=9, dof=9; infinite: var=16, dof=∞
+    // uc4 = 25² = 625; denom = 9²/9 = 9; ν = round(625/9) = 69
+    const finite = createComponent('f', 'finite', 0, 3, 'normal', 'typeB', 1, 9)
+    const inf = createComponent('i', 'inf', 0, 4, 'normal', 'typeB', 1, Infinity)
+    expect(welchSatterthwaite([finite, inf])).toBe(69)
+  })
+  it('dominant component drives effective dof toward its own dof', () => {
+    // one large component dof=5, one tiny component dof=30 → ν close to 5
+    const large = createComponent('l', 'large', 0, 10, 'normal', 'typeB', 1, 5)
+    const small = createComponent('s', 'small', 0, 0.1, 'normal', 'typeB', 1, 30)
+    const veff = welchSatterthwaite([large, small])
+    expect(veff).toBeGreaterThanOrEqual(5)
+    expect(veff).toBeLessThanOrEqual(30)
+  })
+})
+
+// ─── calculateBudget ─────────────────────────────────────────────────────────
+
+describe('calculateBudget', () => {
+  it('expandedUncertainty = combinedStandardUncertainty × coverageFactor', () => {
+    const c1 = createComponent('a', 'u1', 0, 3, 'normal', 'typeB', 1, Infinity)
+    const c2 = createComponent('b', 'u2', 0, 4, 'normal', 'typeB', 1, Infinity)
+    const b = calculateBudget('Pmax Budget', 'Pmax', 250, [c1, c2], 0.95)
+    expect(b.expandedUncertainty).toBeCloseTo(
+      b.combinedStandardUncertainty * b.coverageFactor, 8
+    )
+  })
+  it('components sorted by percentageContribution descending', () => {
+    const small = createComponent('a', 'small', 0, 1, 'normal', 'typeB', 1, Infinity)
+    const large = createComponent('b', 'large', 0, 5, 'normal', 'typeB', 1, Infinity)
+    const b = calculateBudget('test', 'measurand', 100, [small, large])
+    for (let i = 1; i < b.components.length; i++) {
+      expect(b.components[i - 1].percentageContribution).toBeGreaterThanOrEqual(
+        b.components[i].percentageContribution
+      )
+    }
+  })
+  it('relativeUncertaintyPercent = (U / |measuredValue|) × 100', () => {
+    const c = createComponent('a', 'u', 0, 2, 'normal', 'typeB', 1, Infinity)
+    const b = calculateBudget('test', 'Power', 100, [c])
+    expect(b.relativeUncertaintyPercent).toBeCloseTo(
+      (b.expandedUncertainty / 100) * 100, 6
+    )
+  })
+  it('budget contains all ISO 17025 required fields', () => {
+    const c = createComponent('a', 'u', 0, 1, 'normal', 'typeB', 1, 20)
+    const b = calculateBudget('B1', 'Pmax', 250, [c], 0.95, undefined, 'W', 'y = x', 'IEC 60904-3')
+    expect(b).toHaveProperty('measurand', 'Pmax')
+    expect(b).toHaveProperty('combinedStandardUncertainty')
+    expect(b).toHaveProperty('expandedUncertainty')
+    expect(b).toHaveProperty('coverageFactor')
+    expect(b).toHaveProperty('coverageProbability', 0.95)
+    expect(b).toHaveProperty('effectiveDegreesOfFreedom')
+    expect(b.measurementModel).toBe('y = x')
+    expect(b.standardReference).toBe('IEC 60904-3')
+  })
+  it('percentageContributions sum to 100', () => {
+    const comps = [1, 2, 3].map((v, i) =>
+      createComponent(`c${i}`, `u${i}`, 0, v, 'normal', 'typeB', 1, Infinity)
+    )
+    const b = calculateBudget('sum test', 'X', 50, comps)
+    const total = b.components.reduce((s, c) => s + c.percentageContribution, 0)
+    expect(total).toBeCloseTo(100, 6)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Thursday weekly angle — tests (2026-05-28).

No test infrastructure existed on `main`. Three previous Thursday test PRs (#97, #113, #127) were opened but never merged (all Vercel deployments CANCELED — see #151). This PR re-bootstraps the test suite cleanly.

**91 tests pass on `vitest run v3.2.4` in 637 ms.**

## What's added

| File | Tests | Module |
|------|-------|--------|
| `tests/unit/uncertainty.test.ts` | 35 | `lib/uncertainty.ts` — GUM calculator |
| `tests/unit/iv-curve.test.ts` | 27 | `lib/iv-curve.ts` — I-V correction + NMOT |
| `tests/unit/sun-simulator.test.ts` | 29 | `lib/sun-simulator.ts` — IEC 60904-9 classifier |
| `vitest.config.ts` | — | Vitest 3.2 config with `@/` alias |
| `package.json` | — | `test` / `test:watch` / `test:coverage` scripts |

## Coverage highlights

**`lib/uncertainty.ts`** (GUM / JCGM 100:2008)
- `toStandardUncertainty` — all 5 distributions + expanded flag
- `calculateTypeA` — Bessel correction, n=1 edge case, dof = n-1
- `getCoverageFactor` — tabulated t₉₅/t₉₉, linear interpolation, monotonicity
- `calculateCombinedUncertainty` — 3²+4²=5² sanity, positive/negative correlation, full-negative → 0
- `welchSatterthwaite` — equal-variance case (ν=40), infinite-dof (ν=69), dominant-component bound
- `calculateBudget` — U=uc×k, component sort, Σ% = 100, ISO 17025 required fields

**`lib/iv-curve.ts`**
- `DEFAULT_TEMP_COEFFICIENTS` — regression guard (IEC 60904-1 defaults must not silently change)
- `correctPmaxToSTC` — STC identity, irradiance-only, temp-only, combined correction
- `calculateNMOT` — NMOT reference conditions (T_mod = nmot at G=800, T_amb=20), Ross model, pmaxAtNMOT, thermalLoss, tempDelta
- `generateIrradianceTempModel` — 11 points G=200→1200 @ 100 W/m² steps, temperature monotonicity, pr cross-check vs `calculateNMOT`
- `extractIVParameters` — empty guard, Isc/Voc/Pmax/FF extraction and FF ∈ (0,1]

**`lib/sun-simulator.ts`** (IEC 60904-9 Ed.3)
- `calculateUniformity` — IEC formula (max−min)/(max+min)×100, all 5 grade boundaries
- `calculateTemporalStability` — STI/LTI formula, all threshold grades, overallGrade = worst-of-two
- `overallClassification` — all grade combos + full A+<A<B<C<Fail ordering matrix
- `calculateSpectralMatch` — 6 bands, ratio positivity, min≤mean≤max, grade containment, NaN guard

## Related issues

- Closes part of #92 (zero test coverage on main)
- Refs #152 (security audit — 14 vulns — CI needed to enforce)
- Refs #153 (no GitHub Actions CI; these tests need a workflow to run automatically)
- Refs #151 (Vercel CANCELED — does not block merging this pure-logic test PR)

## Test plan

```bash
npm install
npm test       # vitest run — should show 91 passed, 0 failed
npm run test:coverage   # requires @vitest/coverage-v8 (included)
```

https://claude.ai/code/session_01HR4A9iD8crdFfqvWFW7aQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR4A9iD8crdFfqvWFW7aQz)_