### PR TITLE
docs(solvers): JSDoc for chamber.ts and iec60891.ts exported functions

### DIFF
--- a/lib/chamber.ts
+++ b/lib/chamber.ts
@@ -107,12 +107,24 @@ export const STANDARD_TEST_PROFILES: TestProfile[] = [
   },
 ];
 
-/** Calculate chamber volume in m³ */
+/**
+ * Calculate chamber internal volume from dimensions.
+ * @param dims - Internal dimensions in millimetres (length × width × height)
+ * @returns Volume in m³
+ */
 export function calculateVolume(dims: ChamberDimensions): number {
   return (dims.length * dims.width * dims.height) / 1e9;
 }
 
-/** Calculate required cooling capacity (simplified) */
+/**
+ * Estimate refrigeration cooling capacity required for the chamber.
+ * Uses air mass × specific heat × temperature delta; adds 40 % safety factor
+ * to cover wall losses and simultaneous ramp demand.
+ * @param volume - Chamber volume (m³)
+ * @param tempMin - Minimum test temperature (°C)
+ * @param rampRate - Required cooling ramp rate (°C/min)
+ * @returns Recommended cooling capacity (kW), rounded up to one decimal
+ */
 export function calculateCoolingCapacity(volume: number, tempMin: number, rampRate: number): number {
   const airDensity = 1.2; // kg/m³
   const specificHeat = 1.005; // kJ/(kg·°C)
@@ -124,7 +136,14 @@ export function calculateCoolingCapacity(volume: number, tempMin: number, rampRa
   return Math.ceil((baseCapacity + rampCapacity) * 1.4 * 10) / 10;
 }
 
-/** Calculate required heating capacity */
+/**
+ * Estimate electrical heating capacity required for the chamber.
+ * Mirrors cooling calculation with a 30 % safety factor (heating losses are lower).
+ * @param volume - Chamber volume (m³)
+ * @param tempMax - Maximum test temperature (°C)
+ * @param rampRate - Required heating ramp rate (°C/min)
+ * @returns Recommended heating capacity (kW), rounded up to one decimal
+ */
 export function calculateHeatingCapacity(volume: number, tempMax: number, rampRate: number): number {
   const airDensity = 1.2;
   const specificHeat = 1.005;
@@ -135,7 +154,14 @@ export function calculateHeatingCapacity(volume: number, tempMax: number, rampRa
   return Math.ceil((baseCapacity + rampCapacity) * 1.3 * 10) / 10;
 }
 
-/** Calculate UV system specs */
+/**
+ * Size the UV LED array for a given chamber floor area and irradiance target.
+ * Each LED covers 0.05 m² at 85 W output; uniformity is fixed at ±8.5 %
+ * (complies with IEC 61215 MQT 10 ≤ ±15 % requirement).
+ * @param areaM2 - Chamber floor area to illuminate (m²)
+ * @param targetIntensity - Required UV irradiance (W/m²)
+ * @returns LED count, total installed power (kW), and spatial uniformity (%)
+ */
 export function calculateUVSystem(areaM2: number, targetIntensity: number): {
   ledCount: number;
   totalPower: number;
@@ -149,7 +175,15 @@ export function calculateUVSystem(areaM2: number, targetIntensity: number): {
   return { ledCount, totalPower, uniformity };
 }
 
-/** Generate chamber specification from configuration */
+/**
+ * Build a complete `ChamberSpec` from user-supplied name, dimensions, and test profiles.
+ * Derives worst-case environmental envelope across all profiles, sizes refrigeration,
+ * heating, and UV subsystems, infers feature flags, and generates a cost breakdown.
+ * @param name - Human-readable chamber label (used as spec ID seed)
+ * @param dimensions - Internal dimensions in millimetres
+ * @param testProfiles - One or more IEC test profiles the chamber must support
+ * @returns Fully populated `ChamberSpec` including capacities, features, and cost
+ */
 export function generateChamberSpec(
   name: string,
   dimensions: ChamberDimensions,
@@ -233,7 +267,14 @@ function generateCostBreakdown(
   };
 }
 
-/** Compare two chamber configurations */
+/**
+ * Produce a side-by-side comparison table for two chamber specifications.
+ * Returns one row per key parameter (volume, capacities, UV LEDs, cost, test types),
+ * each annotated with which chamber has the advantage.
+ * @param a - First chamber specification
+ * @param b - Second chamber specification
+ * @returns Array of comparison rows with parameter name, formatted values, and advantage flag
+ */
 export function compareChambers(a: ChamberSpec, b: ChamberSpec): {
   parameter: string;
   specA: string;

--- a/lib/iec60891.ts
+++ b/lib/iec60891.ts
@@ -34,7 +34,14 @@ export interface TranslationResult {
   correctionApplied: string;
 }
 
-/** IEC 60891 Procedure 1 - Temperature coefficient method */
+/**
+ * IEC 60891 Procedure 1 — temperature coefficient method.
+ * Translates an I-V characteristic to standard reference conditions using
+ * explicit temperature coefficients α (Isc) and β (Voc) per IEC 60891:2021 §5.1.
+ * @param input - Measured I-V points with source and target irradiance/temperature
+ * @param params - Coefficients α, β, curve correction factor κ (Ω), and unit flags
+ * @returns Translated I-V array with procedure label and applied-correction string
+ */
 export function translateProcedure1(
   input: TranslationInput,
   params: Procedure1Params
@@ -80,7 +87,14 @@ export interface Procedure2Params {
   rs: number;       // Internal series resistance (Ω)
 }
 
-/** IEC 60891 Procedure 2 - Reference device method */
+/**
+ * IEC 60891 Procedure 2 — reference device method.
+ * Scales currents by the Isc ratio of a co-irradiated reference device, then
+ * applies the series-resistance voltage correction per IEC 60891:2021 §5.2.
+ * @param input - Measured I-V points with source and target irradiance/temperature
+ * @param params - Reference device Isc at both conditions, β (V/°C), and Rs (Ω)
+ * @returns Translated I-V array with procedure label and applied-correction string
+ */
 export function translateProcedure2(
   input: TranslationInput,
   params: Procedure2Params
@@ -121,7 +135,14 @@ export interface Procedure3Input {
   targetTemperature: number;  // Target T (°C)
 }
 
-/** IEC 60891 Procedure 3 - Interpolation between two I-V curves */
+/**
+ * IEC 60891 Procedure 3 — linear interpolation between two I-V curves.
+ * Blends point-by-point voltages and currents from curves measured at two
+ * irradiance levels using the fractional distance f = (G_target − G_low) /
+ * (G_high − G_low), per IEC 60891:2021 §5.3.
+ * @param input - Paired low/high I-V datasets with their irradiance and temperature conditions
+ * @returns Interpolated I-V array (length = min of both input arrays) with procedure metadata
+ */
 export function translateProcedure3(input: Procedure3Input): TranslationResult {
   const { ivDataLow, ivDataHigh, gLow, gHigh, targetIrradiance: gTarget } = input;
   const f = gHigh !== gLow ? (gTarget - gLow) / (gHigh - gLow) : 0;
@@ -162,7 +183,12 @@ export interface RsDeterminationResult {
   details: string;
 }
 
-/** Method 1: From slope near Voc on I-V curve */
+/**
+ * Determine series resistance from the slope of the I-V curve near Voc (Method 1).
+ * Uses points above 85 % of Voc; Rs = −ΔV/ΔI per IEC 60891:2021 Annex A.
+ * @param ivData - Measured I-V points sorted by ascending voltage
+ * @returns Best-fit Rs (Ω), method label, and calculation details string
+ */
 export function determineRsFromSlope(ivData: IVDataPoint[]): RsDeterminationResult {
   const sorted = [...ivData].sort((a, b) => a.voltage - b.voltage);
   const voc = sorted[sorted.length - 1].voltage;
@@ -185,7 +211,16 @@ export function determineRsFromSlope(ivData: IVDataPoint[]): RsDeterminationResu
   };
 }
 
-/** Method 2: From two I-V curves at different irradiances */
+/**
+ * Determine series resistance from two I-V curves at different irradiances (Method 2).
+ * Rs = |ΔVmpp / ΔIsc| where ΔVmpp is the maximum-power-point voltage shift between
+ * the two curves; per IEC 60891:2021 Annex A.2.
+ * @param iv1 - I-V points at irradiance G1
+ * @param iv2 - I-V points at irradiance G2
+ * @param g1 - Irradiance for iv1 (W/m²)
+ * @param g2 - Irradiance for iv2 (W/m²)
+ * @returns Best-fit Rs (Ω), method label, and calculation details string
+ */
 export function determineRsFromTwoCurves(
   iv1: IVDataPoint[],
   iv2: IVDataPoint[],
@@ -218,7 +253,21 @@ export function determineRsFromTwoCurves(
   };
 }
 
-/** Method 3: Iterative fitting - minimize translation error */
+/**
+ * Determine series resistance by iterative fitting to a reference I-V curve (Method 3).
+ * Scans κ from 0 to 5 Ω in 10 mΩ steps; picks the value that minimises the RMS
+ * current error between the Procedure-1-translated curve and a reference.
+ * Per IEC 60891:2021 Annex A.3.
+ * @param ivMeasured - I-V points to translate
+ * @param ivReference - Target reference I-V curve for error minimisation
+ * @param alpha - Isc temperature coefficient (%/°C)
+ * @param beta - Voc temperature coefficient (%/°C)
+ * @param g1 - Measured irradiance (W/m²)
+ * @param g2 - Target irradiance (W/m²)
+ * @param t1 - Measured temperature (°C)
+ * @param t2 - Target temperature (°C)
+ * @returns Best-fit Rs (Ω), method label, and RMS error at optimum
+ */
 export function determineRsIterative(
   ivMeasured: IVDataPoint[],
   ivReference: IVDataPoint[],


### PR DESCRIPTION
## Summary

Friday docs angle — 2026-05-29. Companion to PRs #116 (iv-curve, nmot-noct) and #132 (uncertainty, sun-simulator).

Adds `@param`/`@returns` JSDoc to the two remaining undocumented solver modules that already have unit-test coverage (PR #113) but lack inline documentation for IDE tooling and onboarding.

**`lib/chamber.ts`** — 6 exported functions:
- `calculateVolume` — mm³ → m³ conversion
- `calculateCoolingCapacity` — air-mass × Cp × ΔT, 40 % safety factor, ref IEC 61215 TC/HF ramp requirements
- `calculateHeatingCapacity` — mirrors cooling with 30 % safety factor
- `calculateUVSystem` — LED count/power sizing; notes ±8.5 % uniformity vs IEC 61215 MQT 10 ≤ ±15 % limit
- `generateChamberSpec` — full `ChamberSpec` builder from profiles
- `compareChambers` — side-by-side parameter comparison table

**`lib/iec60891.ts`** — 6 exported functions:
- `translateProcedure1` — α/β temperature coefficient method (IEC 60891:2021 §5.1)
- `translateProcedure2` — reference device Isc-ratio method (§5.2)
- `translateProcedure3` — linear interpolation between two curves (§5.3)
- `determineRsFromSlope` — Rs from near-Voc slope (Annex A)
- `determineRsFromTwoCurves` — Rs from ΔVmpp/ΔIsc at two irradiances (Annex A.2)
- `determineRsIterative` — Rs by RMS minimisation over 0–5 Ω scan (Annex A.3)

## Test plan

- [ ] `npm run build` passes (no type regressions)
- [ ] Hover over any exported function in VS Code / IDE — JSDoc tooltip appears with param descriptions
- [ ] No behaviour change (pure documentation additions)

https://claude.ai/code/session_01YLUZjJscAybPeSjVZsZMCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLUZjJscAybPeSjVZsZMCB)_