### PR TITLE
security(api): file-upload validation + input-length caps on AI routes

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -469,6 +469,15 @@ export async function POST(request: NextRequest) {
       });
     }
 
+    if (message.length > 8_000) {
+      return new Response(
+        JSON.stringify({ error: "Message too long. Maximum 8,000 characters." }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const safeHistory = (Array.isArray(history) ? history : []).slice(-20);
+
     const anthropicKey =
       process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
     const pineconeKey = process.env.PINECONE_API_KEY;
@@ -542,7 +551,7 @@ Guidelines:
 
     // Build messages array
     const claudeMessages = [
-      ...history.slice(-10).map((m) => ({
+      ...safeHistory.slice(-10).map((m) => ({
         role: m.role,
         content: m.content,
       })),

--- a/app/api/sop/generate/route.ts
+++ b/app/api/sop/generate/route.ts
@@ -24,6 +24,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const INPUT_LIMITS: Record<string, number> = {
+      standard: 100,
+      clause: 200,
+      title: 300,
+      additionalContext: 2000,
+      labName: 200,
+      documentNumber: 50,
+    };
+    for (const [field, max] of Object.entries(INPUT_LIMITS)) {
+      const value = body[field] as string | undefined;
+      if (value && value.length > max) {
+        return NextResponse.json(
+          { error: `${field} exceeds maximum length of ${max} characters` },
+          { status: 400 }
+        );
+      }
+    }
+
     const apiKey = process.env.CLAUDE_API_KEY;
     if (!apiKey) {
       return NextResponse.json(

--- a/app/api/vision/detect/route.ts
+++ b/app/api/vision/detect/route.ts
@@ -23,6 +23,22 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "No image provided" }, { status: 400 });
     }
 
+    const ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/tiff", "image/webp"]);
+    const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+    if (!ALLOWED_MIME_TYPES.has(imageFile.type)) {
+      return NextResponse.json(
+        { error: "Invalid file type. Allowed: JPEG, PNG, TIFF, WebP" },
+        { status: 415 }
+      );
+    }
+    if (imageFile.size > MAX_FILE_SIZE_BYTES) {
+      return NextResponse.json(
+        { error: "File too large. Maximum size: 10 MB" },
+        { status: 413 }
+      );
+    }
+
     const apiKey = process.env.ROBOFLOW_API_KEY;
     if (!apiKey) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary

Adds defensive input validation to the three AI-facing API routes that were completely unguarded (identified in issue #139). No external dependencies required.

### `app/api/vision/detect/route.ts`
- Reject uploads with MIME types outside `{image/jpeg, image/png, image/tiff, image/webp}` → HTTP 415
- Reject files exceeding 10 MB → HTTP 413
- Prevents unbounded data being base64-encoded and forwarded to the Roboflow API

### `app/api/sop/generate/route.ts`
- Per-field character caps before the Claude API call:
  - `standard` ≤ 100, `clause` ≤ 200, `title` ≤ 300
  - `additionalContext` ≤ 2,000, `labName` ≤ 200, `documentNumber` ≤ 50
- Bounds the size of the assembled prompt sent to Claude, preventing prompt-stuffing

### `app/api/chat/route.ts`
- `message` capped at 8,000 characters → HTTP 400
- `history` array clamped to last 20 items before further slice-to-10 for Claude
- Guards the streaming endpoint against oversized payloads

## What this does NOT address (tracked in #139)
- Rate limiting (requires Upstash/Vercel KV — tracked separately)
- Session-based auth guard on these routes (draft PR #133)

## Test plan
- [ ] POST `/api/vision/detect` with a `.pdf` file → expect 415
- [ ] POST `/api/vision/detect` with a 15 MB JPEG → expect 413
- [ ] POST `/api/vision/detect` with a valid ≤10 MB PNG → passes validation, reaches Roboflow
- [ ] POST `/api/sop/generate` with `title` > 300 chars → expect 400 with field name in message
- [ ] POST `/api/chat` with `message` of 9,000 chars → expect 400
- [ ] POST `/api/chat` with 25-item history array → only last 20 forwarded

Closes part of #139.

https://claude.ai/code/session_01DtK7HPi8cdJb4a6yXkKnJH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtK7HPi8cdJb4a6yXkKnJH)_