### PR TITLE
ci: add GitHub Actions workflow — lint, type-check, npm audit, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Overnight pipeline check — runs at 02:00 UTC daily
+    - cron: '0 2 * * *'
+
+jobs:
+  lint-and-audit:
+    name: Lint, Type-check & Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Security audit (high+critical)
+        run: npm audit --audit-level=high
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test --if-present


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — the missing CI pipeline repeatedly flagged in issues #90 #98 #138 #148 #152 and weekly health checks #121 #126 #128 #129 #145 #156 #159.
- Two jobs: **lint-and-audit** (npm ci → prisma generate → next lint → tsc --noEmit → npm audit --audit-level=high) and **test** (npm test, no-op until Vitest PR merges).
- Adds a **daily 02:00 UTC cron trigger** so the overnight pipeline-check task has automated coverage.

## Why now

The `npm audit` step will immediately surface the 2 CRITICAL + 7 HIGH CVEs on `main` (next@14.2.18 DoS/info-disclosure, jspdf PDF-object-injection, lodash prototype-pollution, xlsx ReDoS, etc.) on every PR, making it impossible to land new PRs without acknowledging the security state.

## Test plan

- [ ] Push a dummy branch targeting main — confirm both jobs appear in the Actions tab
- [ ] Verify `npm audit --audit-level=high` exits non-zero on the current `main` (expected, surfacing known CVEs)
- [ ] Confirm the cron job appears in the scheduled workflows list

Closes #90 #138 #148 #152

https://claude.ai/code/session_014eDMbPsRVfiTTNGV9FEMtk

---
_Generated by [Claude Code](https://claude.ai/code/session_014eDMbPsRVfiTTNGV9FEMtk)_