### PR TITLE
enhance(ai): upgrade @anthropic-ai/sdk to v0.100, add prompt caching to SOP and Chat routes

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,14 +1,101 @@
 import { NextRequest } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
 
 // ---------------------------------------------------------------------------
 // POST /api/chat – RAG-powered chat endpoint
 // Accepts { message, history }
 // 1. Embeds the user query and retrieves relevant chunks from Pinecone
-// 2. Passes context + history to Claude API for a grounded answer
+// 2. Passes context + history to Claude via the Anthropic SDK (streaming)
 // 3. Streams the response back as text/event-stream
 // Falls back to Claude-only (no RAG) if Pinecone is not configured, and
 // further falls back to a rich demo/mock mode when no API keys are set.
 // ---------------------------------------------------------------------------
+
+// Module-level client — connection-pooled across invocations.
+const client = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY,
+});
+
+/**
+ * Stable assistant instruction block sent with cache_control: ephemeral.
+ * The ~1 200-token block is re-used across chat turns within the 5-minute
+ * cache TTL. Dynamic RAG context is injected as a separate (non-cached)
+ * system block so the stable prefix remains cacheable.
+ */
+const ASSISTANT_SYSTEM = `\
+You are SolarLabX AI Assistant, an expert advisor integrated into a solar PV testing laboratory's \
+unified operations platform. You provide technically accurate, well-referenced answers to questions \
+about PV module testing, laboratory quality management, IEC/ISO standards compliance, and measurement \
+uncertainty.
+
+## Domain Coverage
+
+### PV Testing Standards
+- IEC 61215 series: Design qualification and type approval of crystalline silicon PV modules. \
+Complete MQT test sequences (MQT 01–19), sample requirements per sequence group (A/B/C/D), \
+pass/fail criteria (≤5% power degradation, no major visual defects per Table 1), visual inspection \
+criteria, and sequence diagrams for 8-module minimum test programs.
+- IEC 61730 series: Safety qualification. Application class definitions (Class A/B/C), insulation \
+test voltages (1000 V + 2×Voc for ≥1 min), grounding requirements, bypass diode thermal test \
+(75 °C, 1 h per diode), fire classification.
+- IEC 61853 series: Energy rating. 12-point irradiance × temperature matrix (100–1100 W/m², \
+15–75 °C), temperature coefficient determination (α, β, γ), spectral responsivity, angular response, \
+bifacial correction, energy yield methodology per specific climate datasets.
+- IEC 60904 series: Measurement procedures — I-V curve tracing at STC (60904-1), reference solar \
+device requirements (60904-2), calibration chain from WRR (60904-4), irradiance measurement \
+(60904-6), EQE and spectral response (60904-8), sun simulator classification A+/A/B/C using spectral \
+match, spatial uniformity, temporal instability (60904-9), angle-of-incidence correction (60904-10), \
+bifacial measurement (60904-1-2).
+- IEC 60891: I-V translation procedures — Procedure 1 (α/β temperature coefficients), Procedure 2 \
+(reference Isc ratio), Procedure 3 (linear interpolation between conditions).
+- IEC 62915: Retest after design change. Component change matrix, partial retest eligibility, BoM.
+- IEC 62788: Material testing — backsheet peel, encapsulant UV transmission, junction box pull.
+- IEC 62804 (PID), IEC 61701 (salt mist), IEC 62716 (ammonia), IEC 62782 (dynamic mechanical load).
+
+### Laboratory Quality Management
+- ISO/IEC 17025:2017: Full clause coverage — impartiality and confidentiality (§4–5), resources \
+(personnel competency §6.2, facilities §6.3, equipment and calibration §6.4, traceability §6.5), \
+process requirements (method validation §7.2, sampling §7.3, handling §7.4, technical records §7.5, \
+measurement uncertainty §7.6, quality control §7.7, reporting §7.8), management system (§8).
+- ISO 9001:2015: Context, leadership, planning, support, operation, performance evaluation, \
+improvement.
+- JCGM 100:2008 GUM: Type A (statistical) and Type B (non-statistical) uncertainty evaluation, law \
+of propagation of uncertainty, Welch-Satterthwaite formula for effective degrees of freedom, \
+Student-t coverage factor selection, expanded uncertainty reporting at 95% confidence.
+- NABL 141: Specific accreditation criteria for PV testing laboratories in India.
+- ILAC P14: Policy for uncertainty in calibration.
+
+### SolarLabX Platform
+Point users to the right module:
+- LIMS (/lims): sample registration, test execution workflows, chain of custody, equipment \
+calibration tracking, barcode/QR label generation.
+- QMS (/qms): document control, CAPA management, management review, internal audit scheduling.
+- Audit (/audit): ISO 9001/17025 audit planning, NC/OFI tracking with severity, 8D/CAR \
+problem-solving, auditor competency.
+- Projects (/projects): test project Gantt charts, milestone tracking, resource allocation, client \
+deliverables, project costing.
+- Uncertainty Calculator (/uncertainty): GUM budget builder with Type A/B components, Monte Carlo \
+simulation (GUM-S1), Welch-Satterthwaite, k-factor selection, budget PDF export.
+- Vision AI (/vision-ai): AI-powered defect detection (EL, IR, visual inspection) via Roboflow; \
+crack, hotspot, snail trail, PID classification.
+- SOP Generator (/sop-gen): AI-assisted SOP authoring referenced to IEC/ISO clauses.
+- Reports (/reports): ISO 17025-compliant automated test report generation with digital signatures.
+- Sun Simulator (/sun-simulator): IEC 60904-9 classification — spectral match, spatial uniformity, \
+temporal stability assessment.
+- Chamber Config (/chamber-config): environmental chamber specifications, CFD visualisation, quoting.
+- Procurement (/procurement): RFQ, Technical Bid Evaluation, PO tracking, FAT/SAT management.
+
+## Response Guidelines
+
+1. **Cite precisely**: Standard code + edition year + clause (e.g., "IEC 61215-1:2021 §7.4.3").
+2. **Use structured markdown**: Tables for comparison data, numbered steps for procedures.
+3. **State acceptance criteria numerically**: "power degradation ≤ 5%" — never just "acceptable".
+4. **Distinguish certainty levels**: Separate information directly from the standard versus reasoned \
+interpretation. State assumptions explicitly.
+5. **Point to SolarLabX modules**: When a module directly addresses the question, mention it by name \
+and route path.
+6. **Uncertainty**: Remind users that ISO/IEC 17025 §7.8.3 requires test reports to include a \
+statement of measurement uncertainty with coverage factor and confidence level.`;
 
 interface ChatMessage {
   role: "user" | "assistant";
@@ -22,13 +109,10 @@ async function queryPinecone(
   topK = 5
 ): Promise<{ text: string; source: string; score: number }[]> {
   const apiKey = process.env.PINECONE_API_KEY;
-  const indexHost = process.env.PINECONE_INDEX; // full host URL or index name
+  const indexHost = process.env.PINECONE_INDEX;
   if (!apiKey || !indexHost) return [];
 
-  // Support both full host URL and index-name style
-  const host = indexHost.startsWith("http")
-    ? indexHost
-    : `https://${indexHost}`;
+  const host = indexHost.startsWith("http") ? indexHost : `https://${indexHost}`;
 
   const res = await fetch(`${host}/query`, {
     method: "POST",
@@ -36,11 +120,7 @@ async function queryPinecone(
       "Api-Key": apiKey,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      vector: queryEmbedding,
-      topK,
-      includeMetadata: true,
-    }),
+    body: JSON.stringify({ vector: queryEmbedding, topK, includeMetadata: true }),
   });
 
   if (!res.ok) {
@@ -68,10 +148,7 @@ async function embedText(text: string): Promise<number[]> {
       Authorization: `Bearer ${openaiKey}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      model: "text-embedding-3-small",
-      input: text,
-    }),
+    body: JSON.stringify({ model: "text-embedding-3-small", input: text }),
   });
 
   if (!res.ok) {
@@ -83,63 +160,25 @@ async function embedText(text: string): Promise<number[]> {
   return data.data?.[0]?.embedding ?? [];
 }
 
-// ---- Claude streaming helper -----------------------------------------------
+// ---- SDK streaming helper --------------------------------------------------
 
 async function* streamClaude(
-  systemPrompt: string,
-  messages: { role: string; content: string }[]
+  systemBlocks: Anthropic.TextBlockParam[],
+  messages: Anthropic.MessageParam[]
 ): AsyncGenerator<string> {
-  const apiKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
-  if (!apiKey) throw new Error("NO_API_KEY");
-
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": apiKey,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 4096,
-      stream: true,
-      system: systemPrompt,
-      messages,
-    }),
+  const stream = client.messages.stream({
+    model: "claude-sonnet-4-6",
+    max_tokens: 4096,
+    system: systemBlocks,
+    messages,
   });
 
-  if (!res.ok) {
-    const err = await res.text();
-    console.error("Claude API error:", err);
-    throw new Error(`Claude API ${res.status}`);
-  }
-
-  const reader = res.body?.getReader();
-  if (!reader) throw new Error("No response body");
-
-  const decoder = new TextDecoder();
-  let buf = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buf += decoder.decode(value, { stream: true });
-
-    const lines = buf.split("\n");
-    buf = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (!line.startsWith("data: ")) continue;
-      const payload = line.slice(6).trim();
-      if (payload === "[DONE]") return;
-      try {
-        const evt = JSON.parse(payload);
-        if (evt.type === "content_block_delta" && evt.delta?.text) {
-          yield evt.delta.text;
-        }
-      } catch {
-        // ignore non-JSON lines
-      }
+  for await (const event of stream) {
+    if (
+      event.type === "content_block_delta" &&
+      event.delta.type === "text_delta"
+    ) {
+      yield event.delta.text;
     }
   }
 }
@@ -371,38 +410,20 @@ Use the **Uncertainty Calculator** module in SolarLabX for automated computation
   },
 };
 
-function findDemoResponse(query: string): {
-  answer: string;
-  sources: string[];
-} {
+function findDemoResponse(query: string): { answer: string; sources: string[] } {
   const q = query.toLowerCase();
 
   if (q.includes("61215") || (q.includes("test") && q.includes("sequence")))
     return DEMO_RESPONSES["iec 61215"];
-  if (
-    q.includes("qms") ||
-    q.includes("audit") ||
-    q.includes("checklist") ||
-    q.includes("17025")
-  )
+  if (q.includes("qms") || q.includes("audit") || q.includes("checklist") || q.includes("17025"))
     return DEMO_RESPONSES["qms audit"];
   if (q.includes("62915") || q.includes("design change") || q.includes("bom"))
     return DEMO_RESPONSES["iec 62915"];
-  if (
-    q.includes("uncertainty") ||
-    q.includes("budget") ||
-    q.includes("gum") ||
-    q.includes("measurement")
-  )
+  if (q.includes("uncertainty") || q.includes("budget") || q.includes("gum") || q.includes("measurement"))
     return DEMO_RESPONSES["uncertainty"];
-  if (
-    q.includes("calibration") ||
-    q.includes("equipment") ||
-    q.includes("traceability")
-  )
+  if (q.includes("calibration") || q.includes("equipment") || q.includes("traceability"))
     return DEMO_RESPONSES["calibration"];
 
-  // Generic fallback
   return {
     answer: `Thank you for your question about "${query}".
 
@@ -433,22 +454,14 @@ async function* streamDemo(
   query: string
 ): AsyncGenerator<{ type: "text" | "sources"; data: string }> {
   const resp = findDemoResponse(query);
-
-  // Stream the answer character-by-character in small chunks for realistic effect
   const chars = resp.answer;
   let i = 0;
   while (i < chars.length) {
-    const chunkSize = Math.min(
-      3 + Math.floor(Math.random() * 8),
-      chars.length - i
-    );
+    const chunkSize = Math.min(3 + Math.floor(Math.random() * 8), chars.length - i);
     yield { type: "text", data: chars.slice(i, i + chunkSize) };
     i += chunkSize;
-    // Small delay simulated via the stream itself
     await new Promise((r) => setTimeout(r, 10 + Math.random() * 20));
   }
-
-  // Send sources as a final event
   yield { type: "sources", data: JSON.stringify(resp.sources) };
 }
 
@@ -469,8 +482,7 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const anthropicKey =
-      process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
+    const anthropicKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
     const pineconeKey = process.env.PINECONE_API_KEY;
     const openaiKey = process.env.OPENAI_API_KEY;
 
@@ -480,9 +492,7 @@ export async function POST(request: NextRequest) {
       const stream = new ReadableStream({
         async start(controller) {
           for await (const chunk of streamDemo(message)) {
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)
-            );
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
           }
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));
           controller.close();
@@ -518,32 +528,25 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Build system prompt
-    const systemPrompt = `You are SolarLabX AI Assistant, an expert in solar PV testing laboratory operations, IEC/ISO standards, and quality management systems.
+    // Build system blocks: stable instructions are cached; RAG context is not.
+    const systemBlocks: Anthropic.TextBlockParam[] = [
+      {
+        type: "text",
+        text: ASSISTANT_SYSTEM,
+        cache_control: { type: "ephemeral" },
+      },
+    ];
 
-Your knowledge covers:
-- IEC 61215 (Design Qualification), IEC 61730 (Safety), IEC 61853 (Energy Rating)
-- IEC 60904 (Measurement Procedures), IEC 60891 (I-V Translation)
-- IEC 62915 (Type Test Sample Requirements), IEC 62788 (Material Testing)
-- IEC 62804 (PID), IEC 61701 (Salt Mist), IEC 62716 (Ammonia)
-- ISO/IEC 17025 (Lab Competence), ISO 9001 (Quality Management)
-- GUM (Guide to Uncertainty in Measurement)
-- NABL, ILAC, BIS compliance requirements
+    if (ragContext) {
+      systemBlocks.push({
+        type: "text",
+        text: `## Retrieved Context from Knowledge Base\nUse the following retrieved information to ground your answer. Cite the source references.\n\n${ragContext}`,
+      });
+    }
 
-${ragContext ? `\n## Retrieved Context from Knowledge Base\nUse the following retrieved information to ground your answer. Cite the source references.\n\n${ragContext}\n` : ""}
-
-Guidelines:
-- Provide technically accurate, detailed answers with specific clause/section references
-- Use markdown formatting with tables where appropriate
-- When citing standards, include edition year and specific clause numbers
-- If the context doesn't fully answer the question, supplement with your knowledge but note this
-- For procedural questions, include step-by-step instructions with acceptance criteria
-- Always mention relevant SolarLabX modules that can help (e.g., Uncertainty Calculator, LIMS, etc.)`;
-
-    // Build messages array
-    const claudeMessages = [
+    const claudeMessages: Anthropic.MessageParam[] = [
       ...history.slice(-10).map((m) => ({
-        role: m.role,
+        role: m.role as "user" | "assistant",
         content: m.content,
       })),
       { role: "user", content: message },
@@ -554,7 +557,7 @@ Guidelines:
     const stream = new ReadableStream({
       async start(controller) {
         try {
-          for await (const text of streamClaude(systemPrompt, claudeMessages)) {
+          for await (const text of streamClaude(systemBlocks, claudeMessages)) {
             controller.enqueue(
               encoder.encode(
                 `data: ${JSON.stringify({ type: "text", data: text })}\n\n`
@@ -562,7 +565,6 @@ Guidelines:
             );
           }
 
-          // Send sources if we have RAG context
           if (ragSources.length > 0) {
             controller.enqueue(
               encoder.encode(
@@ -595,9 +597,9 @@ Guidelines:
     });
   } catch (error) {
     console.error("Chat API error:", error);
-    return new Response(
-      JSON.stringify({ error: "Internal server error" }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
-    );
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }

--- a/app/api/sop/generate/route.ts
+++ b/app/api/sop/generate/route.ts
@@ -1,17 +1,125 @@
 import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+
+// Module-level client — connection-pooled across invocations.
+const client = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY,
+});
 
 /**
- * POST /api/sop/generate
- * Generate a Standard Operating Procedure using Claude API.
- *
- * Accepts JSON body with:
- * - standard: The IEC/ISO standard identifier
- * - clause: The specific clause/test method
- * - title: SOP title
- * - additionalContext: Optional additional context
- * - labName: Laboratory name
- * - documentNumber: Optional SOP document number
+ * Stable expert-persona system block sent with cache_control: ephemeral.
+ * Repeat SOP generations within the 5-minute cache TTL skip re-tokenising
+ * this ~1 200-token block, reducing latency and input-token costs.
  */
+const SOLAR_EXPERT_SYSTEM = `\
+You are a senior technical writer and solar PV testing specialist embedded in a NABL/ISO 17025 \
+accredited laboratory. Your primary responsibility is producing Standard Operating Procedures (SOPs) \
+that comply with ISO/IEC 17025:2017 Clause 7.2 requirements for documented methods and are ready \
+for internal review, approval, and auditor inspection.
+
+## Domain Expertise
+
+### Standards and Test Methods
+- IEC 61215 series: Design qualification and type approval of crystalline silicon PV modules. \
+MQT test sequences (MQT 01–19), sample requirements per sequence, pass/fail criteria, visual \
+inspection criteria (Table 1), and sequence diagrams.
+- IEC 61730 series: Safety qualification of PV modules. Application class definitions (Class A/B/C), \
+insulation test voltages (1000 V + 2×Voc), grounding requirements, bypass diode thermal test \
+(75 °C, 1 h), fire rating.
+- IEC 61853 series: PV module energy rating. 12-point irradiance × temperature matrix testing, \
+temperature coefficient determination, spectral response measurement, angular response, bifacial \
+correction factors, energy yield calculation methodology.
+- IEC 60904 series: Measurement procedures for PV devices — I-V curve tracing (60904-1), \
+reference solar device requirements (60904-2), calibration chain (60904-4), irradiance measurement \
+(60904-6), EQE and spectral response (60904-8), sun simulator classification A+/A/B/C (60904-9), \
+angle-of-incidence correction (60904-10), bifacial (60904-1-2).
+- IEC 60891: I-V characteristic translation procedures — Procedure 1 (temperature coefficients), \
+Procedure 2 (reference Isc ratio), Procedure 3 (linear interpolation between two conditions).
+- IEC 62915: Type test sample requirements after design changes. Component change matrix, partial \
+retest eligibility criteria, BoM documentation requirements.
+- IEC 62788: Material testing — backsheet peel strength, encapsulant UV transmission, junction box.
+- IEC 62804: Potential-induced degradation (PID) — high-voltage stress at elevated T and RH.
+- IEC 61701: Salt mist corrosion testing. IEC 62716: Ammonia corrosion testing.
+- ISO/IEC 17025:2017: General requirements for laboratory competence — clauses 4–8 in full.
+- JCGM 100:2008 GUM: Type A/B evaluation, law of propagation, Welch-Satterthwaite, coverage factors.
+- NABL 141: Specific accreditation criteria for photovoltaic testing laboratories in India.
+
+### Laboratory Equipment Context
+Solar simulators (IEC 60904-9 Class A+/A/B/C), environmental chambers (thermal cycling, damp heat, \
+humidity-freeze, UV preconditioning), I-V curve tracers with four-wire Kelvin connections, reference \
+solar cells (primary and secondary standards traceable to WRR via PTB/NREL/CalLab), \
+spectroradiometers, insulation testers, EL imaging systems, IR thermography cameras, mechanical load \
+frames, and data acquisition systems.
+
+## Document Writing Standards
+
+1. **Precision**: State every parameter numerically with units and tolerance. Do not write \
+"high temperature" — write "85 °C ± 2 °C". Do not write "several hours" — write "1000 h ± 2 h".
+2. **Traceability**: For every measurement instrument in the PROCEDURE, state the calibration \
+requirement (standard/method, valid certificate required, traceable to SI units via NMI or \
+accredited body).
+3. **Standard references**: Quote clause numbers explicitly, e.g., "per IEC 61215-1:2021 §7.4.1".
+4. **Safety**: Include a bold **SAFETY** warning immediately before steps involving high voltage \
+(≥50 V DC or ≥25 V AC), thermal hazard (chamber > 100 °C), UV radiation, heavy loads, or chemicals.
+5. **Responsibilities**: Map each activity to a specific role — Lab Manager, Test Engineer, \
+Technician, or Quality Assurance. State who executes, who witnesses, who approves.
+6. **Acceptance criteria**: For every step that produces a measurable result, state the pass/fail \
+criterion numerically with the standard clause from which it is derived.
+7. **Revision control**: Always include a REVISION_HISTORY table with columns: \
+Rev | Date | Description | Author | Approved By.
+
+## Output Format
+
+Respond with EXACTLY these section headers, each on its own line, followed by the content:
+
+PURPOSE:
+[One paragraph: measurand, method principle, and scope boundaries]
+
+SCOPE:
+[Applicable module types, test phases, and responsible organisational unit]
+
+REFERENCES:
+[Bulleted list: standard code, edition year, full title]
+
+DEFINITIONS:
+[Abbreviations and technical terms used in this SOP, in alphabetical order]
+
+RESPONSIBILITIES:
+[Role → specific responsibilities; include authorities and limitations]
+
+PROCEDURE:
+[Numbered top-level steps; sub-steps lettered (a, b, c); cover set-up, pre-conditioning, \
+execution, data recording, equipment shutdown, and post-test sample disposition]
+
+RECORDS:
+[Each record on its own line: Form/Log ID | Title | Retention Period | Location]
+
+REVISION_HISTORY:
+[Markdown table: Rev | Date | Description | Author | Approved By — include Rev 1.0 as "Initial issue"]`;
+
+interface SOPPromptParams {
+  standard: string;
+  clause: string;
+  title: string;
+  additionalContext: string;
+  labName: string;
+  documentNumber: string;
+}
+
+function buildSOPUserPrompt(params: SOPPromptParams): string {
+  const lines = [
+    `Generate the SOP for the following:`,
+    ``,
+    `STANDARD: ${params.standard}`,
+    `CLAUSE/TEST METHOD: ${params.clause}`,
+    `SOP TITLE: ${params.title}`,
+    `LABORATORY: ${params.labName || "Solar PV Testing Laboratory"}`,
+  ];
+  if (params.documentNumber) lines.push(`DOCUMENT NUMBER: ${params.documentNumber}`);
+  if (params.additionalContext) lines.push(`ADDITIONAL CONTEXT: ${params.additionalContext}`);
+  return lines.join("\n");
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
@@ -24,58 +132,55 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const apiKey = process.env.CLAUDE_API_KEY;
-    if (!apiKey) {
+    if (!(process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY)) {
       return NextResponse.json(
-        { error: "CLAUDE_API_KEY not configured" },
+        { error: "ANTHROPIC_API_KEY not configured" },
         { status: 500 }
       );
     }
 
-    const prompt = buildSOPPrompt({ standard, clause, title, additionalContext, labName, documentNumber });
-
-    // Call Claude API
-    const claudeResponse = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model: "claude-sonnet-4-20250514",
-        max_tokens: 4096,
-        messages: [
-          {
-            role: "user",
-            content: prompt,
-          },
-        ],
-      }),
+    const userPrompt = buildSOPUserPrompt({
+      standard,
+      clause,
+      title,
+      additionalContext,
+      labName,
+      documentNumber,
     });
 
-    if (!claudeResponse.ok) {
-      const errorText = await claudeResponse.text();
-      console.error("Claude API error:", errorText);
-      return NextResponse.json(
-        { error: `Claude API error: ${claudeResponse.status}` },
-        { status: 502 }
-      );
-    }
+    const message = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 8192,
+      system: [
+        {
+          type: "text",
+          text: SOLAR_EXPERT_SYSTEM,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [{ role: "user", content: userPrompt }],
+    });
 
-    const claudeData = await claudeResponse.json();
-    const responseText = claudeData.content?.[0]?.text || "";
+    const responseText =
+      message.content[0].type === "text" ? message.content[0].text : "";
 
-    // Parse the structured SOP from Claude's response
-    const sop = parseSOPResponse(responseText, { title, standard, clause, labName, documentNumber });
+    const sop = parseSOPResponse(responseText, {
+      title,
+      standard,
+      clause,
+      labName,
+      documentNumber,
+    });
 
     return NextResponse.json({
       sop,
       metadata: {
-        model: "claude-sonnet-4-20250514",
+        model: "claude-sonnet-4-6",
         timestamp: new Date().toISOString(),
         standard,
         clause,
+        cache_read_tokens: message.usage.cache_read_input_tokens ?? 0,
+        cache_created_tokens: message.usage.cache_creation_input_tokens ?? 0,
       },
     });
   } catch (error) {
@@ -87,59 +192,15 @@ export async function POST(request: NextRequest) {
   }
 }
 
-interface SOPPromptParams {
-  standard: string;
-  clause: string;
-  title: string;
-  additionalContext: string;
-  labName: string;
-  documentNumber: string;
-}
-
-function buildSOPPrompt(params: SOPPromptParams): string {
-  return `You are an expert in solar PV testing laboratory operations and ISO/IEC standards. Generate a comprehensive Standard Operating Procedure (SOP) for a solar PV testing laboratory.
-
-STANDARD: ${params.standard}
-CLAUSE/TEST METHOD: ${params.clause}
-SOP TITLE: ${params.title}
-LABORATORY: ${params.labName || "Solar PV Testing Laboratory"}
-${params.documentNumber ? `DOCUMENT NUMBER: ${params.documentNumber}` : ""}
-${params.additionalContext ? `ADDITIONAL CONTEXT: ${params.additionalContext}` : ""}
-
-Generate the SOP with the following sections. Use clear, precise technical language appropriate for a NABL/ISO 17025 accredited laboratory. Include specific procedural steps, acceptance criteria where applicable, and reference standard clauses.
-
-Respond with EXACTLY these section headers (one per section), followed by the content:
-
-PURPOSE:
-[content]
-
-SCOPE:
-[content]
-
-REFERENCES:
-[content]
-
-DEFINITIONS:
-[content]
-
-RESPONSIBILITIES:
-[content]
-
-PROCEDURE:
-[content - include numbered steps with sub-steps]
-
-RECORDS:
-[content - list forms, templates, and records]
-
-REVISION_HISTORY:
-[content]
-
-Ensure the procedure section is detailed with specific steps, temperatures, durations, and acceptance criteria from the standard. Include safety precautions where relevant.`;
-}
-
 function parseSOPResponse(
   text: string,
-  meta: { title: string; standard: string; clause: string; labName: string; documentNumber: string }
+  meta: {
+    title: string;
+    standard: string;
+    clause: string;
+    labName: string;
+    documentNumber: string;
+  }
 ) {
   const sections: Record<string, string> = {
     purpose: "",
@@ -163,7 +224,6 @@ function parseSOPResponse(
     { pattern: /REVISION[_\s]HISTORY:\s*/i, key: "revisionHistory" },
   ];
 
-  // Find positions of each section header
   const positions: { key: string; index: number }[] = [];
   for (const { pattern, key } of sectionKeys) {
     const match = text.match(pattern);
@@ -171,21 +231,18 @@ function parseSOPResponse(
       positions.push({ key, index: match.index + match[0].length });
     }
   }
-
-  // Sort by position
   positions.sort((a, b) => a.index - b.index);
 
-  // Extract content between headers
   for (let i = 0; i < positions.length; i++) {
     const start = positions[i].index;
-    const end = i + 1 < positions.length ? positions[i + 1].index : text.length;
-    // Find the start of the next section header (go back to find the header)
-    let endPos = end;
+    let endPos =
+      i + 1 < positions.length ? positions[i + 1].index : text.length;
     if (i + 1 < positions.length) {
-      // Find the actual header text before the next section
       const nextKey = sectionKeys.find((s) => s.key === positions[i + 1].key);
       if (nextKey) {
-        const headerMatch = text.substring(positions[i].index).match(nextKey.pattern);
+        const headerMatch = text
+          .substring(positions[i].index)
+          .match(nextKey.pattern);
         if (headerMatch && headerMatch.index !== undefined) {
           endPos = positions[i].index + headerMatch.index;
         }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
+    "@anthropic-ai/sdk": "^0.100.0",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",


### PR DESCRIPTION
## Wednesday enhancement — 2026-06-03

Angle: **Enhancement** (Wednesday weekly angle)

---

## Summary

- Upgrade `@anthropic-ai/sdk` from `^0.39.0` to `^0.100.0` (61 minor versions behind)
- Migrate `/api/sop/generate` from raw `fetch` to typed SDK with prompt caching on the stable expert-persona system block
- Migrate `/api/chat` from raw `fetch` + manual SSE parsing to `client.messages.stream()` with prompt caching on the stable assistant instruction block; RAG context kept in a non-cached second block
- Fix retired model alias `claude-sonnet-4-20250514` → `claude-sonnet-4-6` in both routes
- Fix env-var: `/api/sop/generate` was checking only `CLAUDE_API_KEY`; now checks `ANTHROPIC_API_KEY || CLAUDE_API_KEY`

---

## Changes

### `package.json`
```diff
- "@anthropic-ai/sdk": "^0.39.0",
+ "@anthropic-ai/sdk": "^0.100.0",
```

### `/api/sop/generate/route.ts`
- **Before**: raw `fetch("https://api.anthropic.com/v1/messages", { ... })` with manual JSON parsing
- **After**: `client.messages.create({ system: [{ type: "text", text: SOLAR_EXPERT_SYSTEM, cache_control: { type: "ephemeral" } }], ... })`
- New `SOLAR_EXPERT_SYSTEM` constant (~1 200 tokens) covers full standards list, equipment context, 7 document conventions, and the exact output-format spec — cached for 5 minutes
- Variable parts (standard, clause, title, context) go in the user message only
- `max_tokens` raised 4 096 → 8 192 (long SOPs were being truncated)
- Response metadata now exposes `cache_read_tokens` and `cache_created_tokens`

### `/api/chat/route.ts`
- **Before**: `streamClaude()` used raw `fetch` with a manual SSE line-parser (`buf.split("\n")`, `line.slice(6)`, manual JSON decode)
- **After**: `client.messages.stream({ ... })` iterated with `for await (const event of stream)` — SDK handles all SSE framing, reconnection, and type narrowing
- New `ASSISTANT_SYSTEM` constant (~1 200 tokens) covers all IEC/ISO standards, ISO 17025 clause map, GUM, NABL 141, and all 11 SolarLabX module routes — cached
- System is split into two blocks: cached stable instructions + non-cached dynamic RAG context (changes per query, so must not be cached)
- Demo mode and Pinecone/OpenAI helpers are unchanged

---

## Why prompt caching matters here

The SOP generator is called repeatedly for similar standards (IEC 61215, IEC 61730, …) in the same lab session. Without caching, the ~1 200-token expert system is re-tokenised on every call. With `cache_control: ephemeral`, the first call writes to cache; subsequent calls within 5 minutes read from cache — reducing input-token cost by ~90% on the cached block and cutting TTFT.

For the chat endpoint, the assistant system is even more stable across a conversation. The RAG context block, which changes on every turn, is intentionally kept in a separate non-cached block so the stable prefix remains cacheable regardless of what context is retrieved.

---

## Test plan

- [ ] `npm install` — verify `@anthropic-ai/sdk@0.100.x` resolves
- [ ] Set `ANTHROPIC_API_KEY` in `.env.local` and hit `POST /api/sop/generate` with `{ standard, clause, title }` — confirm structured SOP returned and `cache_created_tokens > 0` in metadata on first call
- [ ] Second call to `/api/sop/generate` (same standard, within 5 min) — confirm `cache_read_tokens > 0`
- [ ] Hit `POST /api/chat` with a test message — confirm SSE stream delivers `{ type: "text" }` chunks and final `[DONE]`
- [ ] No `ANTHROPIC_API_KEY` set → `/api/chat` falls through to demo mode correctly
- [ ] TypeScript: `npx tsc --noEmit` — no new type errors

## Related issues
- Closes part of #89 (SDK upgrade — was targeting 0.92.x, now at 0.100)
- Continues from PR #112 (upgraded to 0.54 on Sat 2026-05-13 branch — never merged to main)

https://claude.ai/code/session_01Jpe2ZNhd7uYcEHnL9out3n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jpe2ZNhd7uYcEHnL9out3n)_