### PR TITLE
security(api): auth + Zod on 8 remaining data-plane routes — Saturday 2026-06-06

### DIFF
--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,7 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAuth } from "@/lib/api-auth";
 import { auditPlans, auditFindings, carReports, auditMetrics } from "@/lib/data/audit-data";
 
+const AuditPostSchema = z.object({
+  action: z.enum(["create-plan", "create-finding", "create-car", "update-finding-status", "update-car-step"]),
+  findingId: z.string().max(50).optional(),
+  newStatus: z.string().max(50).optional(),
+  carId: z.string().max(50).optional(),
+  step: z.string().max(100).optional(),
+  title: z.string().max(300).optional(),
+  description: z.string().max(5000).optional(),
+  standard: z.string().max(100).optional(),
+  severity: z.enum(["minor", "major", "critical", "ofi"]).optional(),
+  auditor: z.string().max(200).optional(),
+  auditee: z.string().max(200).optional(),
+});
+
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url);
   const type = searchParams.get("type");
   const standard = searchParams.get("standard");
@@ -24,7 +43,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ metrics: auditMetrics });
   }
 
-  // Default: audit plans
   let plans = [...auditPlans];
   if (standard) plans = plans.filter((p) => p.standard === standard);
   if (status) plans = plans.filter((p) => p.status === status);
@@ -33,11 +51,17 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const { action } = body;
+  const { error } = await requireAuth();
+  if (error) return error;
 
-  if (action === "create-plan") {
-    // In production, this would save to database via Prisma
+  const raw = await request.json();
+  const parsed = AuditPostSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request", issues: parsed.error.issues }, { status: 400 });
+  }
+  const body = parsed.data;
+
+  if (body.action === "create-plan") {
     return NextResponse.json({
       success: true,
       message: "Audit plan created successfully",
@@ -45,7 +69,7 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  if (action === "create-finding") {
+  if (body.action === "create-finding") {
     return NextResponse.json({
       success: true,
       message: "Finding recorded successfully",
@@ -53,7 +77,7 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  if (action === "create-car") {
+  if (body.action === "create-car") {
     return NextResponse.json({
       success: true,
       message: "CAR/8D report initiated",
@@ -61,19 +85,17 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  if (action === "update-finding-status") {
-    const { findingId, newStatus } = body;
+  if (body.action === "update-finding-status") {
     return NextResponse.json({
       success: true,
-      message: `Finding ${findingId} status updated to ${newStatus}`,
+      message: `Finding status updated`,
     });
   }
 
-  if (action === "update-car-step") {
-    const { carId, step } = body;
+  if (body.action === "update-car-step") {
     return NextResponse.json({
       success: true,
-      message: `CAR ${carId} advanced to ${step}`,
+      message: `CAR advanced`,
     });
   }
 

--- a/app/api/lims/equipment/route.ts
+++ b/app/api/lims/equipment/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/api-auth'
 import { mockEquipment } from '@/lib/mock-data'
 import { getDaysUntil } from '@/lib/utils'
 
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
   const category = searchParams.get('category')

--- a/app/api/lims/samples/route.ts
+++ b/app/api/lims/samples/route.ts
@@ -1,11 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAuth } from '@/lib/api-auth'
 import { mockSamples } from '@/lib/mock-data'
 import { generateId } from '@/lib/utils'
 import type { Sample } from '@/lib/types'
 
+const SamplePostSchema = z.object({
+  clientName: z.string().min(1).max(200),
+  clientEmail: z.string().email().max(200).optional().or(z.literal('')),
+  clientOrganization: z.string().max(200).optional(),
+  sampleType: z.string().min(1).max(100),
+  manufacturer: z.string().min(1).max(200),
+  modelNumber: z.string().min(1).max(100),
+  serialNumber: z.string().min(1).max(100),
+  batchNumber: z.string().max(100).optional(),
+  testStandard: z.string().min(1).max(100),
+  priority: z.enum(['urgent', 'high', 'normal', 'low']).optional(),
+  notes: z.string().max(2000).optional(),
+  projectId: z.string().max(100).optional(),
+  lengthMm: z.number().positive().optional().nullable(),
+  widthMm: z.number().positive().optional().nullable(),
+  thicknessMm: z.number().positive().optional().nullable(),
+  weightKg: z.number().positive().optional().nullable(),
+  assignedProtocolIds: z.array(z.string().max(100)).max(50).optional(),
+})
+
 const samples = [...mockSamples]
 
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
   const standard = searchParams.get('standard')
@@ -46,7 +71,15 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json()
+  const { error } = await requireAuth();
+  if (error) return error;
+
+  const raw = await request.json()
+  const parsed = SamplePostSchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', issues: parsed.error.issues }, { status: 400 })
+  }
+  const body = parsed.data
 
   const newSample: Sample = {
     id: String(samples.length + 1),
@@ -60,10 +93,10 @@ export async function POST(request: NextRequest) {
     modelNumber: body.modelNumber,
     serialNumber: body.serialNumber,
     batchNumber: body.batchNumber || '',
-    lengthMm: body.lengthMm || null,
-    widthMm: body.widthMm || null,
-    thicknessMm: body.thicknessMm || null,
-    weightKg: body.weightKg || null,
+    lengthMm: body.lengthMm ?? null,
+    widthMm: body.widthMm ?? null,
+    thicknessMm: body.thicknessMm ?? null,
+    weightKg: body.weightKg ?? null,
     status: 'received',
     currentLocation: 'Receiving Area',
     storageLocation: '',

--- a/app/api/lims/tests/route.ts
+++ b/app/api/lims/tests/route.ts
@@ -1,12 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAuth } from '@/lib/api-auth'
 import { mockTestExecutions } from '@/lib/mock-data'
 import { generateId } from '@/lib/utils'
 import { getTemplateById } from '@/lib/test-templates'
 import type { TestExecution } from '@/lib/types'
 
+const TestPostSchema = z.object({
+  sampleId: z.string().min(1).max(100),
+  protocolId: z.string().min(1).max(100),
+  protocolName: z.string().max(200).optional(),
+  standardReference: z.string().max(100).optional(),
+  technicianId: z.string().max(100).optional(),
+  technicianName: z.string().max(200).optional(),
+  inputData: z.record(z.unknown()).optional(),
+})
+
 const testExecutions = [...mockTestExecutions]
 
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
   const sampleId = searchParams.get('sampleId')
@@ -40,7 +55,15 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json()
+  const { error } = await requireAuth();
+  if (error) return error;
+
+  const raw = await request.json()
+  const parsed = TestPostSchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', issues: parsed.error.issues }, { status: 400 })
+  }
+  const body = parsed.data
 
   const template = getTemplateById(body.protocolId)
 

--- a/app/api/procurement/route.ts
+++ b/app/api/procurement/route.ts
@@ -1,7 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAuth } from "@/lib/api-auth";
 import { rfqs, vendors, purchaseOrders, tbeMatrix, procurementMetrics } from "@/lib/data/procurement-data";
 
+const ProcurementPostSchema = z.object({
+  action: z.enum(["create-rfq", "create-po", "evaluate-vendor", "approve-po", "update-fat-sat", "submit-tbe"]),
+  vendorId: z.string().max(100).optional(),
+  poId: z.string().max(100).optional(),
+  rfqId: z.string().max(100).optional(),
+  approvedBy: z.string().max(200).optional(),
+  newStatus: z.string().max(100).optional(),
+  scores: z.record(z.number()).optional(),
+});
+
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url);
   const type = searchParams.get("type");
   const id = searchParams.get("id");
@@ -44,7 +59,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ metrics: procurementMetrics });
   }
 
-  // Default: summary
   return NextResponse.json({
     summary: {
       openPOs: purchaseOrders.filter((po) => !["Closed", "Delivered"].includes(po.status)).length,
@@ -56,10 +70,17 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const { action } = body;
+  const { error } = await requireAuth();
+  if (error) return error;
 
-  if (action === "create-rfq") {
+  const raw = await request.json();
+  const parsed = ProcurementPostSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request", issues: parsed.error.issues }, { status: 400 });
+  }
+  const body = parsed.data;
+
+  if (body.action === "create-rfq") {
     return NextResponse.json({
       success: true,
       message: "RFQ created successfully",
@@ -67,7 +88,7 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  if (action === "create-po") {
+  if (body.action === "create-po") {
     return NextResponse.json({
       success: true,
       message: "Purchase order created",
@@ -75,36 +96,20 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  if (action === "evaluate-vendor") {
-    const { vendorId, scores } = body;
-    return NextResponse.json({
-      success: true,
-      message: `Vendor ${vendorId} evaluation updated`,
-    });
+  if (body.action === "evaluate-vendor") {
+    return NextResponse.json({ success: true, message: "Vendor evaluation updated" });
   }
 
-  if (action === "approve-po") {
-    const { poId, approvedBy } = body;
-    return NextResponse.json({
-      success: true,
-      message: `PO ${poId} approved by ${approvedBy}`,
-    });
+  if (body.action === "approve-po") {
+    return NextResponse.json({ success: true, message: "PO approved" });
   }
 
-  if (action === "update-fat-sat") {
-    const { poId, newStatus } = body;
-    return NextResponse.json({
-      success: true,
-      message: `PO ${poId} FAT/SAT status updated to ${newStatus}`,
-    });
+  if (body.action === "update-fat-sat") {
+    return NextResponse.json({ success: true, message: "FAT/SAT status updated" });
   }
 
-  if (action === "submit-tbe") {
-    const { rfqId } = body;
-    return NextResponse.json({
-      success: true,
-      message: `TBE submitted for RFQ ${rfqId}`,
-    });
+  if (body.action === "submit-tbe") {
+    return NextResponse.json({ success: true, message: "TBE submitted" });
   }
 
   return NextResponse.json({ error: "Unknown action" }, { status: 400 });

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,7 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAuth } from "@/lib/api-auth";
 import { projects, projectMetrics } from "@/lib/data/projects-data";
 
+const ProjectPostSchema = z.object({
+  action: z.enum(["create", "update-task", "add-milestone", "allocate-resource"]),
+  projectId: z.string().max(100).optional(),
+  taskId: z.string().max(100).optional(),
+  resourceType: z.string().max(100).optional(),
+  resourceName: z.string().max(200).optional(),
+  updates: z.record(z.unknown()).optional(),
+  title: z.string().max(300).optional(),
+  description: z.string().max(5000).optional(),
+});
+
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url);
   const id = searchParams.get("id");
   const status = searchParams.get("status");
@@ -36,10 +52,17 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json();
-  const { action } = body;
+  const { error } = await requireAuth();
+  if (error) return error;
 
-  if (action === "create") {
+  const raw = await request.json();
+  const parsed = ProjectPostSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request", issues: parsed.error.issues }, { status: 400 });
+  }
+  const body = parsed.data;
+
+  if (body.action === "create") {
     return NextResponse.json({
       success: true,
       message: "Project created successfully",
@@ -47,27 +70,24 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  if (action === "update-task") {
-    const { projectId, taskId, updates } = body;
+  if (body.action === "update-task") {
     return NextResponse.json({
       success: true,
-      message: `Task ${taskId} in project ${projectId} updated`,
+      message: `Task updated`,
     });
   }
 
-  if (action === "add-milestone") {
-    const { projectId } = body;
+  if (body.action === "add-milestone") {
     return NextResponse.json({
       success: true,
-      message: `Milestone added to project ${projectId}`,
+      message: `Milestone added`,
     });
   }
 
-  if (action === "allocate-resource") {
-    const { projectId, resourceType, resourceName } = body;
+  if (body.action === "allocate-resource") {
     return NextResponse.json({
       success: true,
-      message: `${resourceType} "${resourceName}" allocated to project ${projectId}`,
+      message: `Resource allocated`,
     });
   }
 

--- a/app/api/qms/capa/route.ts
+++ b/app/api/qms/capa/route.ts
@@ -1,12 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAuth } from '@/lib/api-auth'
 import { mockCAPAs } from '@/lib/mock-data'
 import { generateId } from '@/lib/utils'
 import { EIGHT_D_STEPS } from '@/lib/constants'
 import type { CAPA } from '@/lib/types'
 
+const CAPAPostSchema = z.object({
+  title: z.string().min(1).max(300),
+  type: z.enum(['corrective', 'preventive']).optional(),
+  priority: z.enum(['critical', 'high', 'normal', 'low']).optional(),
+  source: z.string().max(200).optional(),
+  description: z.string().max(5000).optional(),
+  assignedTo: z.string().max(200).optional(),
+  targetCompletionDate: z.string().datetime({ offset: true }).optional().or(z.string().regex(/^\d{4}-\d{2}-\d{2}T/).optional()),
+  relatedDocuments: z.array(z.string().max(100)).max(20).optional(),
+})
+
 const capas = [...mockCAPAs]
 
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
   const type = searchParams.get('type')
@@ -39,7 +55,15 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json()
+  const { error } = await requireAuth();
+  if (error) return error;
+
+  const raw = await request.json()
+  const parsed = CAPAPostSchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', issues: parsed.error.issues }, { status: 400 })
+  }
+  const body = parsed.data
 
   const newCAPA: CAPA = {
     id: String(capas.length + 1),

--- a/app/api/qms/documents/route.ts
+++ b/app/api/qms/documents/route.ts
@@ -1,10 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAuth } from '@/lib/api-auth'
 import { mockDocuments } from '@/lib/mock-data'
 import type { QMSDocument } from '@/lib/types'
+
+const DocPostSchema = z.object({
+  documentNumber: z.string().min(1).max(50),
+  title: z.string().min(1).max(300),
+  category: z.enum(['procedure', 'work_instruction', 'form', 'policy', 'manual', 'record']).optional(),
+  author: z.string().max(200).optional(),
+  department: z.string().max(100).optional(),
+  standardReference: z.string().max(200).optional(),
+  content: z.string().max(50000).optional(),
+})
 
 const documents = [...mockDocuments]
 
 export async function GET(request: NextRequest) {
+  const { error } = await requireAuth();
+  if (error) return error;
+
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
   const category = searchParams.get('category')
@@ -41,13 +56,21 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const body = await request.json()
+  const { error } = await requireAuth();
+  if (error) return error;
+
+  const raw = await request.json()
+  const parsed = DocPostSchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', issues: parsed.error.issues }, { status: 400 })
+  }
+  const body = parsed.data
 
   const newDoc: QMSDocument = {
     id: String(documents.length + 1),
     documentNumber: body.documentNumber,
     title: body.title,
-    category: body.category,
+    category: body.category || 'procedure',
     status: 'draft',
     version: '1.0',
     revision: 1,

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -1,0 +1,11 @@
+import { getServerSession } from 'next-auth'
+import { NextResponse } from 'next/server'
+import { authOptions } from '@/lib/auth'
+
+export async function requireAuth() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user) {
+    return { session: null, error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  return { session, error: null }
+}


### PR DESCRIPTION
## Summary

Saturday security angle. Prior PRs (#117 #119 #133 #158) guarded the 5 AI/proxy routes. This PR closes the remaining **8 data-plane routes** that were publicly callable with no session check and accepted raw JSON with no input validation.

### `lib/api-auth.ts` (new)
`requireAuth()` wraps `getServerSession(authOptions)` — returns a 401 `NextResponse` when no session, so every call site is one line.

### Routes hardened

| Route | Before | After |
|---|---|---|
| `GET /api/audit` | public | `requireAuth()` |
| `POST /api/audit` | public, no validation | `requireAuth()` + `AuditPostSchema` (action enum, all fields bounded) |
| `GET /api/lims/samples` | public | `requireAuth()` |
| `POST /api/lims/samples` | public, raw body → Sample | `requireAuth()` + `SamplePostSchema` (email, lengths, priority enum) |
| `GET /api/lims/tests` | public | `requireAuth()` |
| `POST /api/lims/tests` | public, raw body → TestExecution | `requireAuth()` + `TestPostSchema` |
| `GET /api/lims/equipment` | public | `requireAuth()` |
| `GET /api/projects` | public | `requireAuth()` |
| `POST /api/projects` | public, resourceName echo'd raw | `requireAuth()` + `ProjectPostSchema` (action enum, strings bounded) |
| `GET /api/procurement` | public | `requireAuth()` |
| `POST /api/procurement` | public, approvedBy echo'd raw | `requireAuth()` + `ProcurementPostSchema` (action enum) |
| `GET /api/qms/documents` | public | `requireAuth()` |
| `POST /api/qms/documents` | public, content unbounded | `requireAuth()` + `DocPostSchema` (content max 50 000) |
| `GET /api/qms/capa` | public | `requireAuth()` |
| `POST /api/qms/capa` | public, relatedDocuments unvalidated | `requireAuth()` + `CAPAPostSchema` (array max 20, type/priority enums) |

## Test plan
- [ ] Unauthenticated `curl -X POST /api/lims/samples` returns `401 Unauthorized`
- [ ] Authenticated POST with valid body returns `201` as before
- [ ] POST with oversized `content` field (>50 000 chars) returns `400` with Zod issues
- [ ] POST with invalid enum value (e.g. `action: "hack"`) returns `400`
- [ ] GET without session cookie returns `401` on all 8 routes

## Open items not in this PR
- `next` 14→16 major upgrade (#86)
- `xlsx` replacement (#87 / #136)
- `dompurify` upgrade (#88)
- CSP / `next.config` security headers (companion to #117)

https://claude.ai/code/session_01LKvVaq6Gm3YZ2Dh32Si6FP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKvVaq6Gm3YZ2Dh32Si6FP)_