### PR TITLE
security: HTTP security headers + jspdf CVSS-8.1 patch — Saturday 2026-06-07

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,92 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "X-DNS-Prefetch-Control",
+    value: "on",
+  },
+  // CSP in report-only mode — promotes to enforcing once coverage is confirmed
+  // (upgrade to Content-Security-Policy once visual testing confirms no breakage)
+  {
+    key: "Content-Security-Policy-Report-Only",
+    value: [
+      "default-src 'self'",
+      // Next.js 14 App Router requires unsafe-inline + unsafe-eval for hydration
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      // blob: needed by jsPDF / react-pdf for generated documents
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      // worker-src blob: needed for @react-pdf/renderer's PDF worker
+      "worker-src 'self' blob:",
+      // External API endpoints used by the app
+      "connect-src 'self' https://api.anthropic.com https://detect.roboflow.com https://storage.roboflow.com",
+      "frame-src 'none'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join("; "),
+  },
+];
+
 const nextConfig = {
   images: {
     remotePatterns: [
+      // Vercel preview deployments
+      {
+        protocol: "https",
+        hostname: "*.vercel.app",
+      },
+      // Roboflow — defect detection image storage
+      {
+        protocol: "https",
+        hostname: "storage.roboflow.com",
+      },
+      {
+        protocol: "https",
+        hostname: "detect.roboflow.com",
+      },
+      // GitHub user avatars (used by NextAuth session display)
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+      // Broad fallback for lab equipment/module image URLs from external sources;
+      // tighten once image domains are fully enumerated (see #180)
       {
         protocol: "https",
         hostname: "**",
       },
     ],
   },
-  transpilePackages: ['@react-pdf/renderer'],
+  transpilePackages: ["@react-pdf/renderer"],
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
     "jsbarcode": "^3.12.3",
-    "jspdf": "^4.2.0",
+    "jspdf": "^4.2.1",
     "lucide-react": "^0.460.0",
     "next": "14.2.18",
     "next-auth": "^4.24.10",


### PR DESCRIPTION
## Summary

Saturday security angle — 2026-06-07.

Previous Saturday PRs (#117 #119 #133 #158 #177) covered API auth, Zod input validation, and file-upload guards. This PR fills the two remaining high-impact gaps at the edge/transport layer.

---

## 1. HTTP security headers (`next.config.mjs`)

Five **enforcing** headers applied to all routes via `headers()`:

| Header | Value | Threat mitigated |
|--------|-------|-----------------|
| `X-Frame-Options` | `DENY` | Clickjacking |
| `X-Content-Type-Options` | `nosniff` | MIME-type confusion attacks |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer leakage of lab data URLs |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), interest-cohort=()` | Browser sensor API hijacking; FLoC opt-out |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Forces HTTPS, eligible for HSTS preload list |

**CSP in report-only mode** (`Content-Security-Policy-Report-Only`) tuned for:
- Next.js 14 App Router hydration (`unsafe-inline`, `unsafe-eval`)
- jsPDF and `@react-pdf/renderer` PDF generation (`blob:` worker/img)
- Anthropic and Roboflow API calls (`connect-src` allowlist)

Once the report log shows no violations in production, promote to enforcing `Content-Security-Policy` (tracked in #180).

## 2. `jspdf ^4.2.0` → `^4.2.1` (`package.json`)

Fixes **GHSA-7x6v-j9x4-qf24** — PDF Object Injection, CVSS **8.1**.  
4.2.1 is a safe patch release; no API changes.  
This is the only CVE in the dep-drift snapshot (#179) with a drop-in patch available today.

## 3. `remotePatterns` — explicit host enumeration

Added named entries for the four known image sources before the broad `**` wildcard:
- `*.vercel.app` — preview deployments
- `storage.roboflow.com` / `detect.roboflow.com` — defect detection
- `avatars.githubusercontent.com` — NextAuth avatar display

The wildcard fallback is retained with a TODO comment pointing to #180 so a follow-up PR can remove it once all module image domains are fully catalogued.

---

## Test plan
- [ ] `next build` passes (config-only change)
- [ ] Browser DevTools → Network → response headers show `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Strict-Transport-Security` on any page load
- [ ] No `Content-Security-Policy` violations block page load (report-only means no enforcement)
- [ ] Browser console shows `Content-Security-Policy-Report-Only` violation reports (if any) for calibration
- [ ] `jsPDF` PDF export still works (Report, SOP export)

## Open items not in this PR
- #86 — `next` 14→16 (DoS CVE)
- #87 / #136 / #174 — `xlsx` replacement (no upstream fix)
- #88 — `dompurify` upgrade
- #164 — CI workflow merge (lint/type-check/audit on main)
- #173 / #162 — Vercel production deployment (all builds CANCELED)
- #180 — tighten `remotePatterns` wildcard

https://claude.ai/code/session_012CZDkr2xWWUx9nfXX8aEs7

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZDkr2xWWUx9nfXX8aEs7)_