### PR TITLE
refactor(protocol-types): StandardName literal union + typed PROTOCOLS_BY_STANDARD

### DIFF
--- a/lib/protocol-types.ts
+++ b/lib/protocol-types.ts
@@ -1,6 +1,8 @@
 // Protocol Form System Types for SolarLabX
 // ISO 17025 / ISO 9001 compliant protocol checksheet system
 
+export type StandardName = 'IEC 61215' | 'IEC 61730' | 'IEC 61853' | 'IEC 61701'
+
 export type ProtocolCategory = 'electrical' | 'environmental' | 'mechanical' | 'visual' | 'safety'
 export type RawDataType = 'flasher_iv' | 'el_image' | 'ir_image' | 'insulation_log' | 'chamber_log' | 'generic' | 'none'
 export type FieldType = 'number' | 'text' | 'boolean' | 'select' | 'textarea' | 'date'
@@ -50,7 +52,7 @@ export interface ProtocolDefinition {
   id: string
   code: string           // e.g. "MQT 10.2"
   name: string
-  standard: string       // e.g. "IEC 61215"
+  standard: StandardName
   standardYear: string
   clause: string         // e.g. "4.2"
   category: ProtocolCategory

--- a/lib/protocols/index.ts
+++ b/lib/protocols/index.ts
@@ -2,7 +2,7 @@ import { IEC61215_PROTOCOLS } from './iec61215'
 import { IEC61730_PROTOCOLS } from './iec61730'
 import { IEC61853_PROTOCOLS } from './iec61853'
 import { IEC61701_PROTOCOLS } from './iec61701'
-import type { ProtocolDefinition } from '@/lib/protocol-types'
+import type { ProtocolDefinition, StandardName } from '@/lib/protocol-types'
 
 export const ALL_PROTOCOLS: ProtocolDefinition[] = [
   ...IEC61215_PROTOCOLS,
@@ -11,7 +11,7 @@ export const ALL_PROTOCOLS: ProtocolDefinition[] = [
   ...IEC61701_PROTOCOLS,
 ]
 
-export const PROTOCOLS_BY_STANDARD: Record<string, ProtocolDefinition[]> = {
+export const PROTOCOLS_BY_STANDARD: Record<StandardName, ProtocolDefinition[]> = {
   'IEC 61215': IEC61215_PROTOCOLS,
   'IEC 61730': IEC61730_PROTOCOLS,
   'IEC 61853': IEC61853_PROTOCOLS,
@@ -20,6 +20,10 @@ export const PROTOCOLS_BY_STANDARD: Record<string, ProtocolDefinition[]> = {
 
 export function getProtocolById(id: string): ProtocolDefinition | undefined {
   return ALL_PROTOCOLS.find(p => p.id === id)
+}
+
+export function getProtocolsByStandard(standard: StandardName): ProtocolDefinition[] {
+  return PROTOCOLS_BY_STANDARD[standard]
 }
 
 export { IEC61215_PROTOCOLS, IEC61730_PROTOCOLS, IEC61853_PROTOCOLS, IEC61701_PROTOCOLS }


### PR DESCRIPTION
## Summary

Monday refactor angle — 2026-06-08.

- Add `StandardName = 'IEC 61215' | 'IEC 61730' | 'IEC 61853' | 'IEC 61701'` literal union to `lib/protocol-types.ts`
- Change `ProtocolDefinition.standard` from wide `string` to `StandardName` — typos in standard names are now compile-time errors
- Tighten `PROTOCOLS_BY_STANDARD` from `Record<string, …>` to `Record<StandardName, …>` — TypeScript enforces exhaustiveness, so a missing standard entry is caught at build time
- Add `getProtocolsByStandard(standard: StandardName)` typed utility alongside the existing `getProtocolById`, removing the need for callers to index the map with an unvalidated string key

No behaviour change. All existing callers read `.standard` for display only.

## Files changed

| File | Change |
|------|--------|
| `lib/protocol-types.ts` | +`StandardName` union; `standard: string → StandardName` |
| `lib/protocols/index.ts` | `Record<string,…> → Record<StandardName,…>`; add `getProtocolsByStandard` |

## Test plan

- [ ] `npx tsc --noEmit` passes (requires PR #164 to merge ci.yml first, or run locally)
- [ ] Protocol selector still renders all four standard groups
- [ ] `getProtocolsByStandard('IEC 61215')` returns the expected array

## Related

Part of the `@ts-nocheck` / type-tightening sweep started in #166 (GUMCalculator) and #146 (export-utils).

https://claude.ai/code/session_014Y32NXkD2hdYx7cTTubbjj

---
_Generated by [Claude Code](https://claude.ai/code/session_014Y32NXkD2hdYx7cTTubbjj)_