### PR TITLE
chore(bulk-removal): strip @ts-nocheck from all 22 components/ui/ files

### DIFF
--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";

--- a/components/ui/breadcrumbs.tsx
+++ b/components/ui/breadcrumbs.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import Link from "next/link";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as React from "react";
 import { cn } from "@/lib/utils";
 

--- a/components/ui/command-palette.tsx
+++ b/components/ui/command-palette.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client"
 
 import * as React from "react"

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import React from "react";

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as React from "react";
 import { cn } from "@/lib/utils";
 

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/loading-skeleton.tsx
+++ b/components/ui/loading-skeleton.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import { cn } from "@/lib/utils";

--- a/components/ui/page-header.tsx
+++ b/components/ui/page-header.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import React from "react";

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as React from "react";
 import { cn } from "@/lib/utils";
 

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import * as React from "react";
 import { cn } from "@/lib/utils";
 

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 "use client";
 
 import * as React from "react";


### PR DESCRIPTION
## Summary

Tuesday bulk-removal — 2026-06-09.

Continues the `@ts-nocheck` sweep started in:
- PR #146 — `lib/export-utils.ts`
- PR #166 — `components/uncertainty/GUMCalculator.tsx`

This batch covers all **22 shadcn/ui primitive wrappers** in `components/ui/`.

### Why these files are safe to un-suppress

shadcn/ui components are TypeScript-native by design:
- They import fully-typed Radix UI primitives (`@radix-ui/*`)
- They use `class-variance-authority` with explicit variant maps (no implicit `any`)
- They reference only `cn()` from `lib/utils` (typed `string → string`)
- They export typed `React.ComponentPropsWithoutRef` / `React.ElementRef` shapes

The `@ts-nocheck` directives were added during initial scaffolding and provide no benefit — they only mask errors that may accumulate as callers evolve.

### Files changed (22)

`avatar` · `badge` · `breadcrumbs` · `button` · `card` · `command-palette` · `dialog` · `dropdown-menu` · `empty-state` · `input` · `label` · `loading-skeleton` · `page-header` · `progress` · `scroll-area` · `select` · `separator` · `slider` · `table` · `tabs` · `textarea` · `tooltip`

**22 deletions, no additions. No behaviour change.**

### Remaining @ts-nocheck scope

~228 suppressors remain outside `components/ui/` (down from ~381 before the sweep). Highest-value next targets:
- `components/reports/` (12 files)
- `components/data-analysis/` (31 files)
- `components/qms/` (11 files)

## Test plan

- [ ] `npx tsc --noEmit` passes (requires PR #164 ci.yml to merge first, or run locally)
- [ ] All shadcn components render correctly in the app
- [ ] No new lint errors introduced

https://claude.ai/code/session_012HUFoheQYLDaKWfHEWcBaG

---
_Generated by [Claude Code](https://claude.ai/code/session_012HUFoheQYLDaKWfHEWcBaG)_