### PR TITLE
refactor(nmot-noct): MountingType literal union + applyTempCoeff helper — Monday 2026-06-15

### DIFF
--- a/lib/nmot-noct.ts
+++ b/lib/nmot-noct.ts
@@ -1,11 +1,13 @@
 // NMOT/NOCT Calculator per IEC 61215 and IEC 61853
 
+export type MountingType = "open_rack" | "close_roof" | "bipv";
+
 export interface NMOTInput {
   nocTmeasured: number;   // Measured NOCT (°C) from IEC 61215 MQT 05
   windSpeed: number;      // m/s (default 1 m/s for NMOT)
   ambientTemp: number;    // °C
   irradiance: number;     // W/m² (typically 800 for NMOT, 800 for NOCT)
-  mountingType: "open_rack" | "close_roof" | "bipv";
+  mountingType: MountingType;
 }
 
 export interface NMOTResult {
@@ -34,15 +36,20 @@ export interface ModuleSpecs {
 }
 
 // Mounting correction factors per IEC 61853-2
-const MOUNTING_CORRECTIONS: Record<string, number> = {
+const MOUNTING_CORRECTIONS: Record<MountingType, number> = {
   open_rack: 0,
   close_roof: 3,
   bipv: 6,
 };
 
+// Apply a linear temperature coefficient: 1 + (alpha%/°C) × ΔT
+function applyTempCoeff(alphaPct: number, dT: number): number {
+  return 1 + (alphaPct / 100) * dT;
+}
+
 // Calculate NMOT per IEC 61215:2021 (replaces NOCT)
 export function calculateNMOT(input: NMOTInput): number {
-  const correction = MOUNTING_CORRECTIONS[input.mountingType] || 0;
+  const correction = MOUNTING_CORRECTIONS[input.mountingType];
   // NMOT = NOCT_measured + correction - (for wind speed difference)
   // IEC 61215:2021 defines NMOT conditions: 800 W/m², 20°C, 1 m/s wind
   const windCorrection = (input.windSpeed - 1) * -2; // approximate correction
@@ -50,8 +57,8 @@ export function calculateNMOT(input: NMOTInput): number {
 }
 
 // Calculate NOCT (legacy per IEC 61215:2005)
-export function calculateNOCT(measuredNOCT: number, mountingType: string): number {
-  return measuredNOCT + (MOUNTING_CORRECTIONS[mountingType] || 0);
+export function calculateNOCT(measuredNOCT: number, mountingType: MountingType): number {
+  return measuredNOCT + MOUNTING_CORRECTIONS[mountingType];
 }
 
 // Calculate cell temperature at any operating conditions
@@ -77,12 +84,12 @@ export function calculatePerformanceAtNMOT(
   const cellTemp = calculateCellTemp(ambientTemp, irradiance, nmot);
   const dT = cellTemp - 25; // Difference from STC (25°C)
 
-  const tempDerate = 1 + moduleSpecs.tempCoefficients.alphaPmax / 100 * dT;
+  const tempDerate = applyTempCoeff(moduleSpecs.tempCoefficients.alphaPmax, dT);
   const irradianceFactor = irradiance / 1000;
 
   const correctedPmax = moduleSpecs.pmaxSTC * irradianceFactor * tempDerate;
-  const correctedVoc = moduleSpecs.vocSTC * (1 + moduleSpecs.tempCoefficients.alphaVoc / 100 * dT);
-  const correctedIsc = moduleSpecs.iscSTC * irradianceFactor * (1 + moduleSpecs.tempCoefficients.alphaIsc / 100 * dT);
+  const correctedVoc = moduleSpecs.vocSTC * applyTempCoeff(moduleSpecs.tempCoefficients.alphaVoc, dT);
+  const correctedIsc = moduleSpecs.iscSTC * irradianceFactor * applyTempCoeff(moduleSpecs.tempCoefficients.alphaIsc, dT);
   const performanceRatio = correctedPmax / (moduleSpecs.pmaxSTC * irradianceFactor);
 
   return {
@@ -125,7 +132,7 @@ export function generatePRCurve(
   return tempRange.map((ta) => {
     const cellTemp = calculateCellTemp(ta, 800, nmot);
     const dT = cellTemp - 25;
-    const tempDerate = 1 + moduleSpecs.tempCoefficients.alphaPmax / 100 * dT;
+    const tempDerate = applyTempCoeff(moduleSpecs.tempCoefficients.alphaPmax, dT);
     const power = moduleSpecs.pmaxSTC * 0.8 * tempDerate; // 800/1000 irradiance factor
     return {
       ambient: ta,


### PR DESCRIPTION
## Summary

Monday refactor angle — 2026-06-15.

Three targeted improvements to `lib/nmot-noct.ts` (150 lines, no behaviour change):

**1. Export `MountingType` literal union**
```ts
// before
const MOUNTING_CORRECTIONS: Record<string, number> = { ... }
export function calculateNOCT(measuredNOCT: number, mountingType: string)

// after
export type MountingType = "open_rack" | "close_roof" | "bipv";
const MOUNTING_CORRECTIONS: Record<MountingType, number> = { ... }
export function calculateNOCT(measuredNOCT: number, mountingType: MountingType)
```
`Record<string, number>` accepted any key silently; `Record<MountingType, number>` is exhaustive — TypeScript will error if a new mounting type is added to the union without a corresponding correction value.

**2. Remove redundant `|| 0` fallback**
With the exhaustive Record, `MOUNTING_CORRECTIONS[input.mountingType]` always returns a number. The `|| 0` guard was hiding the fact that `open_rack` legitimately maps to `0`, not a missing key.

**3. Extract `applyTempCoeff(alphaPct, dT)` helper**
The expression `1 + (alpha / 100) * dT` (IEC 61853-1 linear temperature model) appeared four times — once each for `alphaPmax`, `alphaVoc`, `alphaIsc` in `calculatePerformanceAtNMOT`, and once more for `alphaPmax` in `generatePRCurve`. Four identical copies are replaced with one named helper.

## Weekly health check — 2026-06-15 (Monday)

| Check | Status | Notes |
|-------|--------|-------|
| Overnight pipeline (last 24h) | ⛔ NO RUNS | CI workflow (`ci.yml`) not merged to `main`; daily cron never fires — tracked in #181, #182 |
| npm audit | ⚠️ 2 CRITICAL / 7 HIGH / 5 MOD (14 total) | `jspdf` CVSS-8.1 + `next` CRITICAL; PR #187 (4 overrides) unmerged |
| Dependency drift | ⚠️ 9 major gaps | `next` 14→16, `prisma` 5→7, `@anthropic-ai/sdk` 0.39→0.104, `react` 18→19, `recharts` 2→3 |
| Vercel production | ⛔ ALL CANCELED | 20+ consecutive deployments CANCELED, `target: null` — no production environment configured |
| Numerical solver changes | ✅ None | Last main commit was turtle-diagrams UI (2026-03-25); no benchmark needed |
| Hugging Face Space | ✅ N/A | No HF Space connected |
| Weekly angle | ✅ Monday = Refactor | This PR |

## Test plan

- [ ] `npx tsc --noEmit` passes — no new type errors
- [ ] Existing 33 unit tests in `tests/unit/nmot-noct.test.ts` (PR #170) all pass unchanged — behaviour is identical
- [ ] `npm run build` succeeds

https://claude.ai/code/session_015AT7PLZeN1n6L9QML9sq9J

---
_Generated by [Claude Code](https://claude.ai/code/session_015AT7PLZeN1n6L9QML9sq9J)_