### PR TITLE
security(hardening): next@14.2.25 CVE patch, brace-expansion override, middleware auth — Sat 2026-06-20

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,7 @@
+export { default } from 'next-auth/middleware'
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon\\.ico|login|register|api/auth).*)',
+  ],
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,15 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "**",
+        hostname: "storage.roboflow.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.vercel.app",
+      },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsbarcode": "^3.12.3",
     "jspdf": "^4.2.0",
     "lucide-react": "^0.460.0",
-    "next": "14.2.18",
+    "next": "14.2.25",
     "next-auth": "^4.24.10",
     "next-themes": "^0.4.3",
     "papaparse": "^5.5.3",
@@ -57,6 +57,9 @@
     "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
+  "overrides": {
+    "brace-expansion": "^1.1.12"
+  },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/file-saver": "^2.0.7",
@@ -66,7 +69,7 @@
     "@types/uuid": "^10.0.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
-    "eslint-config-next": "14.2.18",
+    "eslint-config-next": "14.2.25",
     "postcss": "^8.4.49",
     "prisma": "^5.22.0",
     "tailwindcss": "^3.4.15",


### PR DESCRIPTION
## Summary

Saturday security angle — 2026-06-20.

Three targeted hardening changes, each closing a distinct attack surface:

| Change | File(s) | CVE / Advisory | Severity |
|--------|---------|----------------|----------|
| next 14.2.18 → 14.2.25 | `package.json` | CVE-2025-29927 (auth bypass), GHSA-g8wf-bx88-rmbc (SSRF) | CRITICAL CVSS 9.1 |
| brace-expansion override | `package.json` | GHSA-f886-m6hf-6m8v, GHSA-jxxr-4gwj-5jf2 (ReDoS) | HIGH |
| NextAuth middleware | `middleware.ts` (new) | Defense-in-depth for CVE-2025-29927 bypass class | Critical |
| Tighten remotePatterns | `next.config.mjs` | SSRF via Next.js image proxy | HIGH |

## Changes

### 1. `next` 14.2.18 → 14.2.25

**CVE-2025-29927** (CVSS 9.1, authorization bypass): An attacker could send an `x-middleware-subrequest` header to skip middleware auth checks entirely — meaning every protected route was reachable without a valid session if the middleware was the only gate. Fixed in 14.2.25.

**GHSA-g8wf-bx88-rmbc** (SSRF via server actions redirect): Fixed in 14.2.21.

`eslint-config-next` bumped in lockstep (must always match `next` version).

Closes part of issue #201.

### 2. `brace-expansion` npm override (closes #188)

`brace-expansion@<1.1.12` has a catastrophic ReDoS: a 30-char crafted input like `{a,`.repeat(30) triggers exponential backtracking, hanging Node for seconds. This propagates through `minimatch → glob → multiple build-tool and lint deps` in the dependency tree.

```json
"overrides": {
  "brace-expansion": "^1.1.12"
}
```

npm overrides forces every transitive consumer to resolve to the patched line without touching any direct dependency.

### 3. `middleware.ts` — NextAuth edge guard (new file)

```typescript
export { default } from 'next-auth/middleware'
export const config = {
  matcher: ['/((?!_next/static|_next/image|favicon\\.ico|login|register|api/auth).*)'],
}
```

Why this is needed even though PRs #133 and #177 add per-route `requireAuth()` calls: CVE-2025-29927 *specifically* exploited the gap between the middleware layer and route-level checks. The pattern of per-route guards is defense in depth — the primary gate must be middleware. A missing JWT now redirects to `/login` before any Route Handler or Server Component executes.

Public paths excluded: `_next/*` static assets, `favicon.ico`, `/login`, `/register`, `/api/auth/*` (NextAuth endpoints).

### 4. `next.config.mjs` — tighten image remotePatterns

Replaces `hostname: "**"` (any host) with an explicit allowlist:
- `storage.roboflow.com` — Vision AI defect images
- `**.vercel.app` — preview/production assets
- `avatars.githubusercontent.com` — GitHub avatar fallbacks

Prevents SSRF via the Next.js `/api/images?url=` image proxy.

## Still open (not in this PR)

- #174 — `xlsx` → `exceljs` replacement (critical CVE, large migration)
- #201 — `next@15/16` major upgrade (breaking changes, dedicated sprint)
- #202 — Vercel production deployment wiring (infra config, not code)
- #176 — 30 draft PRs awaiting merge decision

## Test plan

- [ ] `npm install` completes without errors on fresh clone
- [ ] `npm audit` reports zero HIGH/CRITICAL after overrides resolve
- [ ] Unauthenticated `GET /api/lims/samples` → 302 redirect to `/login` (middleware fires)
- [ ] Authenticated session → normal access to all protected routes
- [ ] Next.js image optimization still serves `storage.roboflow.com` images in Vision AI
- [ ] No regression on `/login` and `/register` pages (excluded from matcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwneH7HSvvdthH8UmzU5M7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwneH7HSvvdthH8UmzU5M7)_