### PR TITLE
enhance(data-analysis): Grubbs outlier detection + Shewhart SPC control limits

### DIFF
--- a/lib/data-analysis.ts
+++ b/lib/data-analysis.ts
@@ -28,6 +28,7 @@ export interface StatisticalSummary {
   cpk: number
   lsl: number
   usl: number
+  outlierCount: number
 }
 
 export interface HistogramBin {
@@ -36,9 +37,139 @@ export interface HistogramBin {
   midpoint: number
 }
 
+/** Result of a Grubbs iterative outlier test (ISO 5725-2:2019). */
+export interface GrubbsResult {
+  /** Original indices of values flagged as outliers. */
+  outlierIndices: number[]
+  /** Raw values flagged as outliers, in detection order. */
+  outlierValues: number[]
+  /** G statistic of the last tested (most extreme remaining) value. */
+  testStatistic: number
+  /** Tabulated G critical value for the final remaining n at α=0.05. */
+  criticalValue: number
+}
+
+/** Shewhart X-bar control limits for SPC monitoring (ISO 7870-2:2013). */
+export interface ControlLimits {
+  /** Upper Control Limit: mean + 3σ (action limit). */
+  ucl: number
+  /** Lower Control Limit: mean − 3σ (action limit). */
+  lcl: number
+  /** Upper Warning Limit: mean + 2σ (Western Electric Rule 2). */
+  uwl: number
+  /** Lower Warning Limit: mean − 2σ (Western Electric Rule 2). */
+  lwl: number
+  mean: number
+  sigma: number
+}
+
+// Grubbs critical values G_crit at α=0.05 (two-tailed), source: ISO 5725-2:2019 Table C.1
+// Stored as [n, G_crit] pairs; values between entries are linearly interpolated.
+const GRUBBS_CRITICAL_VALUES: [number, number][] = [
+  [3, 1.153], [4, 1.463], [5, 1.672], [6, 1.822], [7, 1.938], [8, 2.032],
+  [9, 2.110], [10, 2.176], [11, 2.234], [12, 2.285], [13, 2.331], [14, 2.371],
+  [15, 2.409], [16, 2.443], [17, 2.475], [18, 2.504], [19, 2.532], [20, 2.557],
+  [25, 2.663], [30, 2.745], [35, 2.811], [40, 2.866], [50, 2.956],
+  [75, 3.079], [100, 3.163], [150, 3.273], [200, 3.338],
+]
+
+function grubbsCriticalValue(n: number): number {
+  if (n < 3) return Infinity
+  const table = GRUBBS_CRITICAL_VALUES
+  if (n <= table[0][0]) return table[0][1]
+  for (let i = 0; i < table.length - 1; i++) {
+    const [n0, g0] = table[i]
+    const [n1, g1] = table[i + 1]
+    if (n <= n1) return g0 + ((n - n0) / (n1 - n0)) * (g1 - g0)
+  }
+  return table[table.length - 1][1]
+}
+
+/**
+ * Iterative Grubbs test for outlier detection (ISO 5725-2:2019, §7.3.1).
+ *
+ * Repeatedly removes the most extreme value while its G statistic exceeds
+ * the critical value at α=0.05, stopping when no outlier is found or when
+ * floor(n/3) values have been removed to protect against masking.
+ *
+ * @param values - Input sample (order-independent).
+ * @param alpha  - Reserved; only α=0.05 tables are currently loaded.
+ * @returns GrubbsResult with outlier indices, values, final G, and critical value.
+ */
+export function detectOutliers(values: number[], alpha = 0.05): GrubbsResult {
+  void alpha // α=0.05 table only; parameter reserved for future extension
+  const pool = values.map((v, i) => ({ v, i }))
+  const outlierIndices: number[] = []
+  const outlierValues: number[] = []
+  let lastG = 0
+  let lastCv = 0
+  const maxRemovals = Math.floor(values.length / 3)
+
+  while (outlierIndices.length < maxRemovals && pool.length >= 3) {
+    const mean = pool.reduce((s, p) => s + p.v, 0) / pool.length
+    const variance = pool.reduce((s, p) => s + (p.v - mean) ** 2, 0) / (pool.length - 1)
+    const s = Math.sqrt(variance)
+    if (s === 0) break
+
+    let extremeIdx = 0
+    let extremeG = 0
+    for (let i = 0; i < pool.length; i++) {
+      const g = Math.abs(pool[i].v - mean) / s
+      if (g > extremeG) { extremeG = g; extremeIdx = i }
+    }
+
+    const cv = grubbsCriticalValue(pool.length)
+    lastG = extremeG
+    lastCv = cv
+
+    if (extremeG <= cv) break
+
+    const removed = pool.splice(extremeIdx, 1)[0]
+    outlierIndices.push(removed.i)
+    outlierValues.push(removed.v)
+  }
+
+  return {
+    outlierIndices,
+    outlierValues,
+    testStatistic: parseFloat(lastG.toFixed(4)),
+    criticalValue: parseFloat(lastCv.toFixed(4)),
+  }
+}
+
+/**
+ * Shewhart X-bar control limits for SPC monitoring (ISO 7870-2:2013, §5).
+ *
+ * Computes action limits (±3σ) and Western Electric warning limits (±2σ)
+ * from the full sample. Intended for individual measurement (ImR) charts
+ * where subgroup size = 1.
+ *
+ * @param values - Ordered measurement sequence.
+ * @returns ControlLimits with ucl, lcl, uwl, lwl, mean, sigma.
+ */
+export function calculateControlLimits(values: number[]): ControlLimits {
+  const n = values.length
+  if (n < 2) {
+    const mean = values[0] ?? 0
+    return { ucl: mean, lcl: mean, uwl: mean, lwl: mean, mean, sigma: 0 }
+  }
+  const mean = values.reduce((a, b) => a + b, 0) / n
+  const sigma = Math.sqrt(values.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1))
+  return {
+    ucl: parseFloat((mean + 3 * sigma).toFixed(4)),
+    lcl: parseFloat((mean - 3 * sigma).toFixed(4)),
+    uwl: parseFloat((mean + 2 * sigma).toFixed(4)),
+    lwl: parseFloat((mean - 2 * sigma).toFixed(4)),
+    mean: parseFloat(mean.toFixed(4)),
+    sigma: parseFloat(sigma.toFixed(4)),
+  }
+}
+
 export function calculateStatistics(values: number[], lsl: number, usl: number): StatisticalSummary {
   const n = values.length
-  if (n === 0) return { mean: 0, stdDev: 0, min: 0, max: 0, median: 0, count: 0, cp: 0, cpk: 0, lsl, usl }
+  if (n === 0) {
+    return { mean: 0, stdDev: 0, min: 0, max: 0, median: 0, count: 0, cp: 0, cpk: 0, lsl, usl, outlierCount: 0 }
+  }
 
   const sorted = [...values].sort((a, b) => a - b)
   const mean = values.reduce((a, b) => a + b, 0) / n
@@ -51,6 +182,8 @@ export function calculateStatistics(values: number[], lsl: number, usl: number):
   const cplower = stdDev > 0 ? (mean - lsl) / (3 * stdDev) : 0
   const cpk = Math.min(cpupper, cplower)
 
+  const { outlierIndices } = detectOutliers(values)
+
   return {
     mean: parseFloat(mean.toFixed(4)),
     stdDev: parseFloat(stdDev.toFixed(4)),
@@ -62,6 +195,7 @@ export function calculateStatistics(values: number[], lsl: number, usl: number):
     cpk: parseFloat(cpk.toFixed(3)),
     lsl,
     usl,
+    outlierCount: outlierIndices.length,
   }
 }
 


### PR DESCRIPTION
## Wednesday enhancement — 2026-06-25

Two new exports in `lib/data-analysis.ts` filling gaps required for ISO 22514 / NABL-accredited SPC monitoring of IEC 61215 power measurements.

---

### `detectOutliers(values, alpha?)` → `GrubbsResult` — ISO 5725-2:2019

Iterative Grubbs test using pre-computed critical values for n=3..200 (linearly interpolated). Stops when no outlier exceeds G_crit at α=0.05, or when `floor(n/3)` values have been removed (masking protection). Returns:
- `outlierIndices` — original array positions, for UI highlighting
- `outlierValues` — the flagged values, for audit trail
- `testStatistic` / `criticalValue` — for display in calibration reports

### `calculateControlLimits(values)` → `ControlLimits` — ISO 7870-2:2013

Shewhart Xbar limits for individual measurement (ImR) charts:
- **UCL / LCL** — mean ± 3σ (action limits)
- **UWL / LWL** — mean ± 2σ (Western Electric Rule 2 warning limits)

### `StatisticalSummary.outlierCount` (new field)

`calculateStatistics()` now runs a Grubbs pass internally and reports `outlierCount` in its return value. **No breaking change** — all existing fields are identical.

---

## Files changed
- `lib/data-analysis.ts` — +100 lines (new interfaces, critical-value table, two new functions, updated `calculateStatistics`)

## Test plan
- [ ] Verify `detectOutliers([1,2,3,4,100])` returns index 4 as outlier
- [ ] Verify `calculateControlLimits([...])` UCL = mean + 3σ
- [ ] Verify `calculateStatistics([...]).outlierCount` matches `detectOutliers` length
- [ ] Existing callers of `calculateStatistics` compile without changes (new field is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_013D3Lvs2i2LBEspYg77oyii

---
_Generated by [Claude Code](https://claude.ai/code/session_013D3Lvs2i2LBEspYg77oyii)_