### PR TITLE
security: jspdf CVSS-9.6 patch + remove wildcard image remotePatterns

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,12 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "**",
-      },
-    ],
+    // Wildcard hostname removed — GHSA-g5qg-72qw-gw5v / GHSA-9g9p-9gw9-jx7f / GHSA-h64f-5h5j-jqjh.
+    // Add explicit entries here when external <Image> sources are needed, e.g.:
+    //   { protocol: "https", hostname: "assets.example.com" }
+    remotePatterns: [],
   },
   transpilePackages: ['@react-pdf/renderer'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
         "jsbarcode": "^3.12.3",
-        "jspdf": "^4.2.0",
+        "jspdf": "^4.2.1",
         "lucide-react": "^0.460.0",
         "next": "14.2.18",
         "next-auth": "^4.24.10",
@@ -6390,9 +6390,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.0.tgz",
-      "integrity": "sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
     "jsbarcode": "^3.12.3",
-    "jspdf": "^4.2.0",
+    "jspdf": "^4.2.1",
     "lucide-react": "^0.460.0",
     "next": "14.2.18",
     "next-auth": "^4.24.10",


### PR DESCRIPTION
## Summary

Saturday security angle — 2026-06-27.

Two focused, low-risk patches that can land on `main` independently of the blocked `next@14→15` upgrade track.

### Changes

**1. jspdf 4.2.0 → 4.2.1** (`package.json` + `package-lock.json`)

| Advisory | Title | CVSS |
|----------|-------|------|
| [GHSA-wfv2-pwc8-crg5](https://github.com/advisories/GHSA-wfv2-pwc8-crg5) | HTML Injection in New Window paths | **9.6** |
| [GHSA-7x6v-j9x4-qf24](https://github.com/advisories/GHSA-7x6v-j9x4-qf24) | PDF Object Injection via FreeText color | **8.1** |

Patch-level bump, no API changes. The `jspdf` lock was pinned to 4.2.0 despite `^4.2.0` in `package.json`.

**2. Remove wildcard `hostname: "**"` from `next.config.mjs`** (`remotePatterns: []`)

The wildcard let the Next.js Image Optimization API proxy **any** HTTPS URL. This is the direct attack surface for:

| Advisory | Impact |
|----------|--------|
| [GHSA-g5qg-72qw-gw5v](https://github.com/advisories/GHSA-g5qg-72qw-gw5v) | Cache Key Confusion for Image Optimization Routes |
| [GHSA-9g9p-9gw9-jx7f](https://github.com/advisories/GHSA-9g9p-9gw9-jx7f) | DoS via Image Optimizer remotePatterns |
| [GHSA-h64f-5h5j-jqjh](https://github.com/advisories/GHSA-h64f-5h5j-jqjh) | DoS in the Image Optimization API |

No `<Image>` components in the current app load from external HTTPS sources. The comment in `next.config.mjs` documents how to add explicit entries if needed.

## Remaining open (not in this PR)

- `next@14 → next@15/16` — 26 CVEs, major version bump (tracked in #86)
- `xlsx` prototype pollution / ReDoS (CVSS 7.8 / 7.5) (tracked in #87)
- `daily-audit.yml` cron never fired on main (see new issue)
- Production Vercel stuck on Mar-25 `main`; 13 security PRs unmerged

## Test plan

- [ ] `npm audit` — jspdf no longer appears as critical after this merge
- [ ] `npm run build` passes (no image optimizer usage broken)
- [ ] PDF export in Reports module still works (jspdf API unchanged at 4.2.x)
- [ ] `/api/reports/generate` still returns valid PDF metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoNaXvZxwVKGFT6Prijpst

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoNaXvZxwVKGFT6Prijpst)_