### PR TITLE
security: remove wildcard image hostname + brace-expansion DoS override

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,13 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "**",
-      },
-    ],
-  },
+  // No remotePatterns: the app never uses next/image with external URLs.
+  // Wildcard hostname was removed to close GHSA-g5qg-72qw-gw5v (Image
+  // Optimization cache-key confusion) and GHSA-xv57-4mr9-wg8v (content
+  // injection via image optimiser).
   transpilePackages: ['@react-pdf/renderer'],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2640,29 +2640,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -2677,6 +2654,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -3502,14 +3496,13 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -3855,13 +3848,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -5489,16 +5475,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "xlsx": "^0.18.5",
     "zod": "^3.23.8"
   },
+  "overrides": {
+    "brace-expansion": "^2.0.1"
+  },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/file-saver": "^2.0.7",


### PR DESCRIPTION
## Summary

Saturday 2026-06-28 security angle. Two targeted, low-risk fixes drawn from this week's `npm audit` (2 critical / 8 high / 6 moderate on main).

- **Remove wildcard `remotePatterns` in `next.config.mjs`** — closes GHSA-g5qg-72qw-gw5v (Image Optimization cache-key confusion) and GHSA-xv57-4mr9-wg8v (content injection via image optimiser). The app has zero usages of ``'&lt;Image src="external-url"&gt;'`` (confirmed by grep), so `hostname: "**"` provided no benefit and exposed the image endpoint to arbitrary external origin abuse.
- **`overrides.brace-expansion: "^2.0.1"` in `package.json`** — closes GHSA-f886-m6hf-6m8v (zero-step sequence → process hang / OOM) and GHSA-jxxr-4gwj-5jf2 (large numeric range defeats `max` cap). The transitive chain `eslint-config-next → minimatch → brace-expansion@1.x` is replaced. brace-expansion 1→2 is API-compatible for programmatic callers; only the deprecated Minimatch class export was removed. npm audit drops from 16 → 15 vulns.

## What is NOT in this PR (handled separately)

| Issue | Draft PR / GitHub issue |
|---|---|
| `next@14.2.18` → 14.2.25 (23+ CVEs incl. Authorization Bypass) | Draft PR #203 |
| `jspdf@4.2.0` PDF Object Injection (CVSS-9.6) | Draft PR #217 |
| `xlsx@0.18.5` Prototype Pollution + ReDoS | Issue #218 (migration plan) |
| 30 unmerged security draft PRs | Issue #219 (merge backlog) |

## Test plan

- [ ] `npm run build` passes (no next/image remotePatterns errors)
- [ ] `npm audit` reports 15 total vulns (down from 16), brace-expansion entries gone
- [ ] No visual regression on image-heavy pages (vision-ai/detect uses `<ImageUploader>`, not `<Image src>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwY6H3A596vvPGJFp64ivL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwY6H3A596vvPGJFp64ivL)_