### PR TITLE
refactor(colors): extract shared SEVERITY_COLORS and LIFECYCLE_COLORS to lib/colors.ts

### DIFF
--- a/components/audit/AuditCalendar.tsx
+++ b/components/audit/AuditCalendar.tsx
@@ -3,18 +3,14 @@
 
 import { AuditPlan } from "@/lib/types/audit";
 import { cn } from "@/lib/utils";
+import { LIFECYCLE_COLORS } from "@/lib/colors";
 
 interface AuditCalendarProps {
   audits: AuditPlan[];
   currentMonth?: Date;
 }
 
-const statusColors: Record<string, string> = {
-  Planned: "bg-blue-200 text-blue-800 border-blue-300",
-  "In Progress": "bg-yellow-200 text-yellow-800 border-yellow-300",
-  Completed: "bg-green-200 text-green-800 border-green-300",
-  Cancelled: "bg-gray-200 text-gray-800 border-gray-300",
-};
+const statusColors = LIFECYCLE_COLORS;
 
 export default function AuditCalendar({ audits, currentMonth = new Date(2026, 2, 1) }: AuditCalendarProps) {
   const year = currentMonth.getFullYear();

--- a/components/complaints/ComplaintsPage.tsx
+++ b/components/complaints/ComplaintsPage.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from 'react'
 import { cn, formatDate } from '@/lib/utils'
+import { SEVERITY_COLORS } from '@/lib/colors'
 import { toast } from 'sonner'
 import { customerComplaints, complaintAnalytics } from '@/lib/data/complaints-data'
 import type { CustomerComplaint } from '@/lib/types'
@@ -15,12 +16,7 @@ const tabs: { key: TabKey; label: string }[] = [
   { key: 'analytics', label: 'Analytics' },
 ]
 
-const severityColors: Record<string, string> = {
-  low: 'bg-blue-100 text-blue-700',
-  medium: 'bg-yellow-100 text-yellow-700',
-  high: 'bg-orange-100 text-orange-700',
-  critical: 'bg-red-100 text-red-700',
-}
+const severityColors = SEVERITY_COLORS
 
 const statusColors: Record<string, string> = {
   registered: 'bg-blue-100 text-blue-700',

--- a/components/customer/CustomerManagementPage.tsx
+++ b/components/customer/CustomerManagementPage.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from 'react'
 import { cn, formatDate } from '@/lib/utils'
+import { SEVERITY_COLORS } from '@/lib/colors'
 import { toast } from 'sonner'
 import { customerComplaints, complaintAnalytics } from '@/lib/data/complaints-data'
 import type { CustomerComplaint } from '@/lib/types'
@@ -37,12 +38,7 @@ const complaintSubTabs: { key: ComplaintSubTab; label: string }[] = [
   { key: 'analytics', label: 'Analytics' },
 ]
 
-const severityColors: Record<string, string> = {
-  low: 'bg-blue-100 text-blue-700',
-  medium: 'bg-yellow-100 text-yellow-700',
-  high: 'bg-orange-100 text-orange-700',
-  critical: 'bg-red-100 text-red-700',
-}
+const severityColors = SEVERITY_COLORS
 
 const statusColors: Record<string, string> = {
   registered: 'bg-blue-100 text-blue-700',

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared Tailwind badge-class maps for common domain values.
+ * Import these instead of redefining local color maps in each component.
+ */
+
+/** low=blue, medium=yellow, high=orange, critical=red — light badge style */
+export const SEVERITY_COLORS: Record<string, string> = {
+  low: "bg-blue-100 text-blue-700",
+  medium: "bg-yellow-100 text-yellow-700",
+  high: "bg-orange-100 text-orange-700",
+  critical: "bg-red-100 text-red-700",
+};
+
+/**
+ * Lifecycle/workflow state badge classes with border accent.
+ * Covers the Planned → In Progress → Completed/Cancelled arc used
+ * by audit, project, and QMS modules.
+ */
+export const LIFECYCLE_COLORS: Record<string, string> = {
+  Draft: "bg-gray-100 text-gray-700 border-gray-200",
+  Planned: "bg-blue-200 text-blue-800 border-blue-300",
+  "In Progress": "bg-yellow-200 text-yellow-800 border-yellow-300",
+  Completed: "bg-green-200 text-green-800 border-green-300",
+  Done: "bg-green-200 text-green-800 border-green-300",
+  Cancelled: "bg-gray-200 text-gray-800 border-gray-300",
+  Failed: "bg-red-200 text-red-800 border-red-300",
+};
+
+/** Returns the SEVERITY_COLORS class for `level`; falls back to `fallback`. */
+export function severityBadgeClass(
+  level: string,
+  fallback = "bg-gray-100 text-gray-700"
+): string {
+  return SEVERITY_COLORS[level.toLowerCase()] ?? fallback;
+}
+
+/** Returns the LIFECYCLE_COLORS class for `status`; falls back to `fallback`. */
+export function lifecycleBadgeClass(
+  status: string,
+  fallback = "bg-gray-100 text-gray-700"
+): string {
+  return LIFECYCLE_COLORS[status] ?? fallback;
+}


### PR DESCRIPTION
## Summary

- Add `lib/colors.ts` with `SEVERITY_COLORS`, `LIFECYCLE_COLORS`, and two typed helper functions (`severityBadgeClass`, `lifecycleBadgeClass`)
- Replace the identical 4-entry `severityColors` local map in `ComplaintsPage.tsx` and `CustomerManagementPage.tsx` with an import of `SEVERITY_COLORS`
- Replace the identical `statusColors` local map in `AuditCalendar.tsx` with `LIFECYCLE_COLORS`

## Motivation

The `severityColors` object (`low/medium/high/critical → bg-*-100 text-*-700`) was defined identically in **6 component files**. The audit `statusColors` (`Planned/In Progress/Completed/Cancelled → bg-*-200 with border`) appears in several more. Each copy is a silent drift risk — a colour tweak must be replicated manually.

## What changed

| File | Change |
|------|--------|
| `lib/colors.ts` (new) | `SEVERITY_COLORS`, `LIFECYCLE_COLORS`, helper functions |
| `components/complaints/ComplaintsPage.tsx` | -5 lines: `const severityColors = SEVERITY_COLORS` |
| `components/customer/CustomerManagementPage.tsx` | -5 lines: same |
| `components/audit/AuditCalendar.tsx` | -4 lines: `const statusColors = LIFECYCLE_COLORS` |

**No visual change** — all call sites index the same map keys with the same Tailwind classes.

## Follow-up

The remaining ~4 files with identical `severityColors` maps (`ComplaintRegistrationForm.tsx`, `EnhancedProjectsDashboard.tsx`, `TestDatabasesTab.tsx`, `RouteCardsPage.tsx`) can be migrated in a separate PR.

_Monday refactor angle — 2026-06-29_

---
_Generated by [Claude Code](https://claude.ai/code/session_01786RbaAaWt6wjHq2vZodaH)_