### PR TITLE
enhance(api): add GET /api/health liveness probe

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import packageJson from "@/package.json";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    version: packageJson.version,
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/health` returning `{ status: "ok", version, timestamp }` — no auth, no external calls, no DB dependency
- Fills a gap flagged repeatedly in past weekly health-check issues (#99, #140): there was no liveness endpoint for Vercel deployment checks or uptime monitoring to poll

Wednesday enhancement angle — 2026-07-01.

## Test plan
- [ ] `curl /api/health` on preview deployment returns 200 with `status: "ok"`
- [ ] Confirm no auth/middleware blocks the route
- [ ] `tsc --noEmit` passes (consistent with existing `app/api/*/route.ts` files; not independently verified in this sandbox — `npm install` failed here on the Prisma binary postinstall due to network restrictions, unrelated to this change)

---

## Weekly automated health-check notes (not part of this diff, informational only)

1. **Overnight data-pipeline jobs**: No new workflow runs in the last 24h. `main` still has no `.github/workflows/` directory — `ci.yml` and `daily-audit.yml` exist only on unmerged draft PRs (#164, #119), so the 02:00 UTC cron never fires. This has been reported in issues #118, #121, #224, and others since May; not re-filing a duplicate today.
2. **Dependency drift / advisories**: `npm audit` — 2 critical, 4 high, 4 moderate. Notably `next@14.2.18` (multiple CVEs incl. CVSS 9.1 auth bypass, fix available in draft PR #203), `jspdf@4.2.0` (CVSS 9.6 HTML injection + object injection, fix in draft PR #217), `xlsx@0.18.5` (prototype pollution + ReDoS, no fix available — replacement tracked in #136). Already covered in detail by yesterday's issue #227.
3. **Solver/numerical module changes**: The last commit merged to `main` (PR #84, turtle-diagrams page) touched no solver/numerical code — nothing to benchmark.
4. **Vercel deployment**: Production (`dpl_GiTfQGgWa8xef5CXpZqU9iHYKSVs`) is READY, but still serving the March 25, 2026 build (PR #84). All later preview deployments are CANCELED (expected — previews for the 55 open, unmerged draft PRs). No Hugging Face Space is connected to this repo.

The root blocker across all four checks is the same one flagged since issue #118 (2026-05-16): **55 open draft PRs and 88 open issues, none merged since PR #84 on 2026-03-25.** Given how many near-duplicate backlog-tracking issues already exist (#118, #121, #140, #141, #172, #176, #213, #214, #222, #224, #227), this PR does not file another one — the actionable fix is merging the existing security PRs (#203, #217, #187), not more reporting.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T8EMfK46to7bZgcxqs2CaH)_